### PR TITLE
Change the Problem.evaluate() interface to accept an Individual instead of a phenome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Being a terse compilation by version of changes.
    * Added a `check_constraints()` operator to the `CGPDecoder` class, to help verify custom algorithms
 
  * API changes
+   * `Problem.evaluate()` now takes an `Individual` instead of a `phenome` as an argument
+     * ^ this is a major API change that is not backword compatible!
+   * `Individual` now has a `phenome` property
    * Mutation operators (`mutate_gaussian()` and `mutate_binomial()`) can now be passed a list of `std` values to adjust the mutation width by gene.
    * Removed undocumented normalization term from `real_rep.problems.CosineFamilyProblem`
    * Expose a `reset` method on `PopulationMetricsPlotProbe`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Being a terse compilation by version of changes.
    * Mutation operators (`mutate_gaussian()` and `mutate_binomial()`) can now be passed a list of `std` values to adjust the mutation width by gene.
    * Removed undocumented normalization term from `real_rep.problems.CosineFamilyProblem`
    * Expose a `reset` method on `PopulationMetricsPlotProbe`
+   * `util.inc_generation()` now takes a `start_generation` argument
 
 
 ## 0.7.0, 8/5/2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Being a terse compilation by version of changes.
    * Removed undocumented normalization term from `real_rep.problems.CosineFamilyProblem`
    * Expose a `reset` method on `PopulationMetricsPlotProbe`
    * `util.inc_generation()` now takes a `start_generation` argument
+   * `genome_mutate_gaussian()` is now a curried function instead of a closure
 
 
 ## 0.7.0, 8/5/2021

--- a/examples/advanced/segmented_representations.ipynb
+++ b/examples/advanced/segmented_representations.ipynb
@@ -59,7 +59,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[array([1, 0, 1, 1, 0]), array([0, 0, 0, 0, 1]), array([0, 1, 1, 1, 1]), array([0, 0, 1, 0, 0])]\n"
+      "[array([0, 1, 1, 1, 0]), array([0, 1, 0, 0, 1]), array([0, 0, 1, 1, 0]), array([0, 0, 0, 1, 1])]\n"
      ]
     }
    ],
@@ -78,11 +78,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 [array([0, 1, 0, 1, 1]), array([0, 0, 1, 1, 0]), array([0, 0, 0, 0, 1])]\n",
-      "1 [array([0, 0, 1, 1, 0]), array([0, 0, 0, 1, 0]), array([0, 0, 0, 0, 1]), array([0, 1, 0, 0, 0])]\n",
-      "2 [array([1, 1, 0, 0, 1])]\n",
-      "3 [array([0, 0, 0, 0, 1]), array([0, 1, 0, 1, 0]), array([1, 0, 1, 1, 0])]\n",
-      "4 [array([0, 1, 1, 0, 1]), array([1, 1, 0, 1, 0]), array([1, 1, 1, 1, 0]), array([0, 1, 0, 0, 0])]\n"
+      "0 [array([1, 0, 1, 0, 0]), array([0, 1, 0, 1, 0]), array([1, 1, 0, 1, 0]), array([0, 1, 0, 1, 0]), array([1, 0, 0, 1, 1])]\n",
+      "1 [array([0, 0, 1, 0, 0]), array([1, 0, 0, 0, 1]), array([0, 0, 1, 1, 1]), array([0, 1, 0, 1, 0]), array([1, 0, 1, 1, 0])]\n",
+      "2 [array([0, 1, 0, 0, 1])]\n",
+      "3 [array([1, 1, 0, 1, 1]), array([1, 1, 0, 0, 0]), array([1, 0, 0, 1, 1]), array([1, 0, 1, 0, 0])]\n",
+      "4 [array([1, 1, 1, 1, 1]), array([1, 0, 0, 1, 1]), array([1, 1, 1, 1, 1])]\n"
      ]
     }
    ],
@@ -112,11 +112,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 [array([1, 3]), array([0, 6]), array([0, 1])]\n",
-      "1 [array([0, 6]), array([0, 2]), array([0, 1]), array([1, 0])]\n",
-      "2 [array([3, 1])]\n",
-      "3 [array([0, 1]), array([1, 2]), array([2, 6])]\n",
-      "4 [array([1, 5]), array([3, 2]), array([3, 6]), array([1, 0])]\n"
+      "0 [array([2, 4]), array([1, 2]), array([3, 2]), array([1, 2]), array([2, 3])]\n",
+      "1 [array([0, 4]), array([2, 1]), array([0, 7]), array([1, 2]), array([2, 6])]\n",
+      "2 [array([1, 1])]\n",
+      "3 [array([3, 3]), array([3, 0]), array([2, 3]), array([2, 4])]\n",
+      "4 [array([3, 7]), array([2, 3]), array([3, 7])]\n"
      ]
     }
    ],
@@ -172,21 +172,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 [array([-3.40231119,  0.43604658,  5.08091891])]\n",
-      "1 [ array([ 1.19156977,  0.74468427, -9.3431648 ]),\n",
-      "  array([4.13376007, 0.67227527, 2.8389859 ]),\n",
-      "  array([-1.35036005, -0.16159234, -5.88014623])]\n",
-      "2 [ array([-3.61662821, -0.16085274,  4.82057054]),\n",
-      "  array([-2.55900795, -0.48237721, -5.81362419])]\n",
-      "3 [ array([-0.14272255,  0.21981472,  0.10823838]),\n",
-      "  array([-0.15293992, -0.821942  ,  1.62435248]),\n",
-      "  array([1.84334389, 0.64284763, 1.19385632])]\n",
-      "4 [array([ 1.39889923, -0.59903152,  6.37915447])]\n",
-      "5 [ array([-1.5994267 , -0.69050754,  2.0867158 ]),\n",
-      "  array([ 3.88378476,  0.87293692, -9.17930249]),\n",
-      "  array([-2.52557113, -0.39187786, -3.91009272]),\n",
-      "  array([4.05377848, 0.69027317, 4.70061672]),\n",
-      "  array([-3.01356327,  0.78726788, -3.22621981])]\n"
+      "0 [ array([-3.75071674,  0.46386065,  1.38181758]),\n",
+      "  array([-2.91537588,  0.60750115,  2.99781769]),\n",
+      "  array([ 3.10691707, -0.12522229,  4.24649363])]\n",
+      "1 [ array([-4.29037119, -0.023013  ,  8.56076735]),\n",
+      "  array([-1.68239181, -0.05078013,  5.68311547])]\n",
+      "2 [ array([-4.78877623,  0.96810368, -5.28102197]),\n",
+      "  array([-3.70132685, -0.1151275 ,  7.56829347])]\n",
+      "3 [ array([4.08965869, 0.9491576 , 3.15840364]),\n",
+      "  array([ 3.06489975, -0.30123501, -8.60561182]),\n",
+      "  array([-0.83505345,  0.60958973,  9.93492934])]\n",
+      "4 [ array([-4.31143984, -0.07241334,  3.48833519]),\n",
+      "  array([ 3.72641803,  0.88241687, -9.98726061])]\n",
+      "5 [ array([ 4.99094859,  0.10459521, -2.89066495]),\n",
+      "  array([-1.48493988,  0.11473388, -4.9696993 ]),\n",
+      "  array([ 3.1259385 , -0.50882668, -3.31544524]),\n",
+      "  array([1.76267056, 0.9116856 , 8.50488626]),\n",
+      "  array([ 3.34513117,  0.9519293 , -8.61929645])]\n"
      ]
     }
    ],
@@ -225,14 +227,18 @@
       "original: [[ 0.  0.]\n",
       " [ 1.  1.]\n",
       " [-1.  0.]] None\n",
-      "mutated: [array([-0.94064896, -1.94892   ]), array([-0.24435059,  1.        ]), array([-1.97594838,  0.        ])] None\n"
+      "mutated: [array([-1.01022109,  0.        ]), array([1.        , 1.70682231]), array([-0.27669487,  0.        ])] None\n"
      ]
     }
    ],
    "source": [
     "original = Individual(np.array([[0.0,0.0],[1.0,1.0],[-1.0,0.0]]))\n",
     "print('original:', original)\n",
-    "mutated = next(apply_mutation(iter([original]), expected_num_mutations=3, mutator=genome_mutate_gaussian(std=1.0)))\n",
+    "mutated = next(apply_mutation(iter([original]),\n",
+    "                              expected_num_mutations=3,\n",
+    "                              mutator=genome_mutate_gaussian(std=1.0)\n",
+    "                             )\n",
+    "              )\n",
     "print('mutated:', mutated)"
    ]
   },
@@ -263,10 +269,10 @@
       " Individual([[0, 0], [1, 1]], IdentityDecoder(), None),\n",
       " Individual([[0, 0], [1, 1]], IdentityDecoder(), None),\n",
       " Individual([[0, 0], [1, 1]], IdentityDecoder(), None)]\n",
-      "new_pop: [Individual([[1, 1]], IdentityDecoder(), None),\n",
-      " Individual([[1, 1]], IdentityDecoder(), None),\n",
-      " Individual([[1, 1]], IdentityDecoder(), None),\n",
+      "new_pop: [Individual([[0, 0]], IdentityDecoder(), None),\n",
       " Individual([[0, 0]], IdentityDecoder(), None),\n",
+      " Individual([[1, 1]], IdentityDecoder(), None),\n",
+      " Individual([[1, 1]], IdentityDecoder(), None),\n",
       " Individual([[1, 1]], IdentityDecoder(), None)]\n"
      ]
     }
@@ -297,11 +303,11 @@
       "     Individual([[0, 0], [1, 1]], IdentityDecoder(), None),\n",
       "     Individual([[0, 0], [1, 1]], IdentityDecoder(), None),\n",
       "     Individual([[0, 0], [1, 1]], IdentityDecoder(), None)]\n",
-      "new_pop: [        Individual([[1, 1], [0, 0], [1, 1]], IdentityDecoder(), None),\n",
-      "         Individual([[0, 0], [1, 1], [0, 0]], IdentityDecoder(), None),\n",
+      "new_pop: [        Individual([[0, 0], [1, 1], [1, 1]], IdentityDecoder(), None),\n",
       "         Individual([[0, 0], [0, 0], [1, 1]], IdentityDecoder(), None),\n",
+      "         Individual([[0, 0], [1, 1], [0, 0]], IdentityDecoder(), None),\n",
       "         Individual([[0, 0], [1, 1], [1, 1]], IdentityDecoder(), None),\n",
-      "         Individual([[0, 0], [1, 1], [1, 1]], IdentityDecoder(), None)]\n"
+      "         Individual([[0, 0], [0, 0], [1, 1]], IdentityDecoder(), None)]\n"
      ]
     }
    ],
@@ -331,11 +337,11 @@
       "     Individual([[0, 0], [1, 1]], IdentityDecoder(), None),\n",
       "     Individual([[0, 0], [1, 1]], IdentityDecoder(), None),\n",
       "     Individual([[0, 0], [1, 1]], IdentityDecoder(), None)]\n",
-      "new_pop: [        Individual([[0, 0], [12345], [1, 1]], IdentityDecoder(), None),\n",
-      "         Individual([[0, 0], [1, 1], [12345]], IdentityDecoder(), None),\n",
-      "         Individual([[0, 0], [1, 1], [12345]], IdentityDecoder(), None),\n",
+      "new_pop: [        Individual([[12345], [0, 0], [1, 1]], IdentityDecoder(), None),\n",
       "         Individual([[0, 0], [12345], [1, 1]], IdentityDecoder(), None),\n",
-      "         Individual([[0, 0], [1, 1], [12345]], IdentityDecoder(), None)]\n"
+      "         Individual([[0, 0], [12345], [1, 1]], IdentityDecoder(), None),\n",
+      "         Individual([[0, 0], [12345], [1, 1]], IdentityDecoder(), None),\n",
+      "         Individual([[12345], [0, 0], [1, 1]], IdentityDecoder(), None)]\n"
      ]
     }
    ],
@@ -375,7 +381,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/leap_ec/binary_rep/problems.py
+++ b/leap_ec/binary_rep/problems.py
@@ -26,20 +26,20 @@ class MaxOnes(ScalarProblem):
         """
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         >>> from leap_ec.individual import Individual
         >>> import numpy as np
         >>> p = MaxOnes()
         >>> ind = Individual(np.array([0, 0, 1, 1, 0, 1, 0, 1, 1]),
         ...                   problem=p)
-        >>> p.evaluate(ind.decode())
+        >>> p.evaluate(ind)
         5
         """
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        return np.count_nonzero(phenome == 1)
+                              f"Got {type(individual.phenome)}."))
+        return np.count_nonzero(individual.phenome == 1)
 
 
 ##############################
@@ -62,9 +62,9 @@ class ImageProblem(ScalarProblem):
         x = ImageOps.fit(x, size)
         return x.convert('1')
 
-    def evaluate(self, phenome):
-        assert (len(phenome) == len(self.flat_img)
-                ), f"Bad genome length: got {len(phenome)}, expected " \
+    def evaluate(self, individual):
+        assert (len(individual.phenome) == len(self.flat_img)
+                ), f"Bad genome length: got {len(individual.phenome)}, expected " \
                    f"{len(self.flat_img)} "
-        diff = np.logical_not(phenome ^ self.flat_img)
+        diff = np.logical_not(individual.phenome ^ self.flat_img)
         return sum(diff)

--- a/leap_ec/executable_rep/executable.py
+++ b/leap_ec/executable_rep/executable.py
@@ -15,8 +15,8 @@ import time
 
 import numpy as np
 
-from leap_ec.problem import ScalarProblem
 from leap_ec.decoder import Decoder
+
 
 ##############################
 # Abstract Class Executable

--- a/leap_ec/executable_rep/problems.py
+++ b/leap_ec/executable_rep/problems.py
@@ -161,6 +161,7 @@ class TruthTableProblem(ScalarProblem):
         entry (in the second one, TTT=F).  So we expect a fitness value of 
         $7/8 = 0.875$:
         
+        >>> from leap_ec import Individual
         >>> problem.evaluate(Individual(executable))
         0.875
 
@@ -238,7 +239,7 @@ class ImageXYProblem(ScalarProblem):
         return fast_output
 
     def evaluate(self, individual):
-        executable = individual
+        executable = individual.phenome
         assert(executable is not None)
         assert(callable(executable))
         # Collect the target image into an array

--- a/leap_ec/executable_rep/problems.py
+++ b/leap_ec/executable_rep/problems.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from leap_ec.real_rep.problems import ScalarProblem
 
-from PIL import Image, ImageOps
+from PIL import Image
 
 
 ##############################
@@ -89,9 +89,10 @@ class EnvironmentProblem(ScalarProblem):
             # Otherwise just look at the shape of the space directly
             return int(np.prod(observation_space.shape))
 
-    def evaluate(self, executable):
-        """Run the environmental simulation using `executable` as a controller,
+    def evaluate(self, individual):
+        """Run the environmental simulation using `executable` phenotype as a controller,
         and use the resulting observations & rewards to compute a fitness value."""
+        executable = individual.phenome
         observations = []
         rewards = []
         for r in range(self.runs):
@@ -135,7 +136,7 @@ class TruthTableProblem(ScalarProblem):
         self.pad_inputs = pad_inputs
         self.name = name
 
-    def evaluate(self, executable):
+    def evaluate(self, individual):
         """
         Say our object function is $(x_0 \wedge x_1) \vee x_3$:
 
@@ -160,7 +161,7 @@ class TruthTableProblem(ScalarProblem):
         entry (in the second one, TTT=F).  So we expect a fitness value of 
         $7/8 = 0.875$:
         
-        >>> problem.evaluate(executable)
+        >>> problem.evaluate(Individual(executable))
         0.875
 
         Note that we our lambda functions above return a list that contains a 
@@ -168,10 +169,11 @@ class TruthTableProblem(ScalarProblem):
         this framework allows us to work with functions of more than one output:
 
         >>> problem = TruthTableProblem(lambda x: [ x[0] and x[1], x[0] or x[1] ], num_inputs=3, num_outputs=2)
-        >>> problem.evaluate(lambda x: [ x[0] and x[1], x[0] or x[1] ])
+        >>> problem.evaluate(Individual(lambda x: [ x[0] and x[1], x[0] or x[1] ]))
         1.0
 
         """
+        executable = individual.phenome
         assert(executable is not None)
         assert(callable(executable))
         input_samples = self._enumerate_tt(self.num_inputs)
@@ -235,7 +237,10 @@ class ImageXYProblem(ScalarProblem):
         fast_output = np.stack(fast_output, axis=1).astype(int)
         return fast_output
 
-    def evaluate(self, executable):
+    def evaluate(self, individual):
+        executable = individual
+        assert(executable is not None)
+        assert(callable(executable))
         # Collect the target image into an array
         # XXX Competing this with loops for testing.
         #     When complete, we can rely on self.img_array

--- a/leap_ec/individual.py
+++ b/leap_ec/individual.py
@@ -68,6 +68,19 @@ class Individual:
         self.problem = problem
         self.decoder = decoder
         self.fitness = None
+        self._phenome = None
+
+    @property
+    def phenome(self):
+        """If the phenome has not yet been decoded, do so."""
+        if self._phenome is None:
+            self.decode()
+        return self._phenome
+
+    @phenome.setter
+    def phenome(self, value):
+        """Manually set the phenome, bypassing the decoder."""
+        self._phenome = value
 
     @classmethod
     def create_population(cls, n, initialize, decoder, problem):
@@ -125,9 +138,16 @@ class Individual:
 
     def decode(self, *args, **kwargs):
         """
+        Determe the indivduals phenome.
+
+        This is done by passing the genome self.decoder.
+
+        The result is both returned and saved to self.phenome.
+
         :return: the decoded value for this individual
         """
-        return self.decoder.decode(self.genome, args, kwargs)
+        self._phenome = self.decoder.decode(self.genome, args, kwargs)
+        return self._phenome
 
     def evaluate_imp(self):
         """ This is the evaluate 'implementation' called by
@@ -136,7 +156,8 @@ class Individual:
             the evaluate process either by tailoring the problem interface or
             that of the given decoder.
         """
-        return self.problem.evaluate(self.decode())
+        self.decode()
+        return self.problem.evaluate(self)
 
     def evaluate(self):
         """ determine this individual's fitness

--- a/leap_ec/ops.py
+++ b/leap_ec/ops.py
@@ -285,8 +285,7 @@ def grouped_evaluate(population: list, problem, max_individuals_per_chunk: int =
 
     fitnesses = []
     for chunk in chunks(population, max_individuals_per_chunk):
-        phenomes = [ ind.decode() for ind in chunk ]
-        fit = problem.evaluate_multiple(phenomes)
+        fit = problem.evaluate_multiple(chunk)
         fitnesses.extend(fit)
 
     for fit, ind in zip(fitnesses, population):

--- a/leap_ec/probe.py
+++ b/leap_ec/probe.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from toolz import curry
 
+from leap_ec import Individual
 from leap_ec.global_vars import context
 from leap_ec import ops as op
 from leap_ec.ops import iteriter_op, listlist_op
@@ -834,7 +835,7 @@ class CartesianPhenotypePlotProbe:
             @np.vectorize
             def v_fun(x, y):
                 phenome = np.concatenate((np.hstack((x,y)), pad))
-                return contours.evaluate(phenome)
+                return contours.evaluate(Individual(phenome))
 
             if granularity is None:
                 granularity = (contours.bounds[1] - contours.bounds[0]) / 50.

--- a/leap_ec/problem.py
+++ b/leap_ec/problem.py
@@ -12,7 +12,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 import numpy as np
 
-from leap_ec import leap_logger_name
+from leap_ec import leap_logger_name, Individual
 from leap_ec.global_vars import context
 
 
@@ -38,9 +38,9 @@ class Problem(ABC):
         super().__init__()
 
     @abstractmethod
-    def evaluate(self, phenome, *args, **kwargs):
+    def evaluate(self, individual: Individual, *args, **kwargs):
         """
-        Evaluate the given individual based on its decoded phenome.
+        Evaluate the given individual.
 
         Practitioners *must* over-ride this member function.
 
@@ -48,18 +48,18 @@ class Problem(ABC):
         maximization problem; if this is a minimization problem, then just
         negate the value when returning the fitness.
 
-        :param phenome:
-        :return: fitness
+        :param individual: the individual to evaluate (this will *not be modified*)
+        :return: the fitness value
         """
         raise NotImplementedError
 
-    def evaluate_multiple(self, phenomes):
+    def evaluate_multiple(self, individuals):
         """Evaluate multiple individuals all at once, returning a list of fitness
         values.
         
         By default this just calls `self.evaluate()` multiple times.  Override this
         if you need to, say, send a group of individuals off to parallel """
-        return [ self.evaluate(p) for p in phenomes ]
+        return [ self.evaluate(ind) for ind in individuals ]
 
     @abstractmethod
     def worse_than(self, first_fitness, second_fitness):
@@ -141,8 +141,9 @@ class FunctionProblem(ScalarProblem):
         super().__init__(maximize)
         self.fitness_function = fitness_function
 
-    def evaluate(self, phenome, *args, **kwargs):
-        return self.fitness_function(phenome, *args, **kwargs)
+    def evaluate(self, individual, *args, **kwargs):
+        
+        return self.fitness_function(individual.phenome, *args, **kwargs)
 
 
 ##############################
@@ -177,18 +178,18 @@ class ConstantProblem(ScalarProblem):
         super().__init__(maximize)
         self.c = c
 
-    def evaluate(self, phenome, *args, **kwargs):
+    def evaluate(self, individual, *args, **kwargs):
         """
         Return a contant value for any input phenome:
 
-        >>> phenome = [0.5, 0.8, 1.5]
-        >>> ConstantProblem().evaluate(phenome)
+        >>> ind = Individual([0.5, 0.8, 1.5])
+        >>> ConstantProblem().evaluate(ind)
         1.0
 
-        >>> ConstantProblem(c=500.0).evaluate('foo bar')
+        >>> ConstantProblem(c=500.0).evaluate(Individual('foo bar'))
         500.0
 
-        :param phenome: real-valued vector to be evaluated
+        :param individual: individual to be evaluated
         :return: 1.0, or the constant defined in the constructor
         """
         return self.c
@@ -213,16 +214,16 @@ class ExternalProcessProblem(ScalarProblem):
         self.command = command
         self.args = args[:] if args else []
         
-    def evaluate(self, phenome):
-        fitnesses = self.evaluate_multiple([ phenome ])
+    def evaluate(self, individual):
+        fitnesses = self.evaluate_multiple([ individual ])
         assert(len(fitnesses) == 1)
         return fitnesses[0]
     
-    def evaluate_multiple(self, phenomes):
+    def evaluate_multiple(self, individuals):
         # Convert the phenomes into one big string
         def phenome_to_str(p):
             return ','.join([ str(x) for x in p ])
-        phenome_bytes = '\n'.join([ phenome_to_str(p) for p in phenomes ]).encode()
+        phenome_bytes = '\n'.join([ phenome_to_str(ind.phenome) for ind in individuals ]).encode()
         
         logger.debug(f"Input: {phenome_bytes}")
 
@@ -240,8 +241,8 @@ class ExternalProcessProblem(ScalarProblem):
         out_strs = outs.split(b'\n')[:-1]  # Ignoring  trailing newline
         fitnesses = [ float(o) for o in out_strs]
         
-        if len(fitnesses) != len(phenomes):
-            raise RuntimeError(f"Expected to receive {len(phenomes)} fitness values back from external simulation, but actually received {len(fitnesses)}.")
+        if len(fitnesses) != len(individuals):
+            raise RuntimeError(f"Expected to receive {len(individuals)} fitness values back from external simulation, but actually received {len(fitnesses)}.")
 
         logger.debug(f"Fitnesses: {fitnesses}\n")
             
@@ -277,7 +278,7 @@ class FitnessOffsetProblem(ScalarProblem):
         if hasattr(problem, 'bounds'):
             self.bounds = problem.bounds
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Evaluates the phenome's fitness in the wrapped function, then
         adds the constant.
@@ -287,10 +288,10 @@ class FitnessOffsetProblem(ScalarProblem):
 
         >>> original = ConstantProblem(c=5.0)
         >>> problem = FitnessOffsetProblem(original, fitness_offset=-3.5)
-        >>> problem.evaluate([0, 1, 2])
+        >>> problem.evaluate(Individual([0, 1, 2]))
         1.5
         """
-        return self.problem.evaluate(phenome) + self.fitness_offset
+        return self.problem.evaluate(individual) + self.fitness_offset
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -316,7 +317,7 @@ class AverageFitnessProblem(Problem):
     >>> p = AverageFitnessProblem(
     ...                 wrapped_problem = NoisyQuarticProblem(),
     ...                 n = 20)
-    >>> x = [ 1, 1, 1, 1 ]
+    >>> x = Individual([ 1, 1, 1, 1 ])
     >>> y = p.evaluate(x)
     >>> print(f"Fitness: {y}")  # The mean of this will be approximately 10
     Fitness: ...
@@ -329,12 +330,12 @@ class AverageFitnessProblem(Problem):
         self.wrapped_problem = wrapped_problem
         self.n = n
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """Evaluates the wrapped function n times sequentially and returns the mean."""
-        fitnesses = [ self.wrapped_problem.evaluate(phenome) for _ in range(self.n) ]
+        fitnesses = [ self.wrapped_problem.evaluate(individual) for _ in range(self.n) ]
         return np.mean(fitnesses)
 
-    def evaluate_multiple(self, phenomes: list):
+    def evaluate_multiple(self, individuals: list):
         """
         Evaluate a collections of phenomes by creating n jobs for each phenome,
         sending all the jobs to the wrapped evaluate_multiple() function, and then
@@ -349,15 +350,15 @@ class AverageFitnessProblem(Problem):
             return means
             
         # Copy each phenome n times, because we're going to evaluate each one n times
-        expanded_phenomes = [ p for p in phenomes for _ in range(self.n) ]
+        expanded_individuals = [ ind for ind in individuals for _ in range(self.n) ]
 
         # Evaluate them
-        fitnesses = self.wrapped_problem.evaluate_multiple(expanded_phenomes)
+        fitnesses = self.wrapped_problem.evaluate_multiple(expanded_individuals)
 
         # Average the copies back together
         contracted_phenomes = mean_by_chunk(fitnesses)
 
-        assert(len(contracted_phenomes) == len(phenomes))
+        assert(len(contracted_phenomes) == len(individuals))
         return contracted_phenomes
 
     def worse_than(self, first_fitness, second_fitness):
@@ -389,8 +390,8 @@ class AlternatingProblem(Problem):
 
         return self.problems[i]
 
-    def evaluate(self, phenome):
-        return self.get_current_problem().evaluate(phenome)
+    def evaluate(self, individual):
+        return self.get_current_problem().evaluate(individual)
 
     def worse_than(self, first_fitness, second_fitness):
         return self.get_current_problem().worse_than(first_fitness, second_fitness)

--- a/leap_ec/real_rep/problems.py
+++ b/leap_ec/real_rep/problems.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.lib.twodim_base import diag
 from numpy.random import random
 
+from leap_ec import Individual
 from leap_ec.problem import FitnessOffsetProblem, ScalarProblem
 
 
@@ -46,20 +47,20 @@ class SpheroidProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> phenome = [0.5, 0.8, 1.5]
-        >>> SpheroidProblem().evaluate(phenome)
+        >>> SpheroidProblem().evaluate(Individual(phenome))
         3.14
 
         :param phenome: real-valued vector to be evaluated
         :return: it's fitness, `sum(phenome**2)`
         """
-        if isinstance(phenome, np.ndarray):
-            return np.sum(phenome ** 2)
-        return sum([x ** 2 for x in phenome])
+        if isinstance(individual.phenome, np.ndarray):
+            return np.sum(individual.phenome ** 2)
+        return sum([x ** 2 for x in individual.phenome])
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -119,23 +120,23 @@ class RastriginProblem(ScalarProblem):
         super().__init__(maximize)
         self.a = a
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> phenome = [1.0/12, 0]
-        >>> RastriginProblem().evaluate(phenome) # doctest: +ELLIPSIS
+        >>> RastriginProblem().evaluate(Individual(phenome)) # doctest: +ELLIPSIS
         0.1409190406...
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        if isinstance(phenome, np.ndarray):
-            return self.a * len(phenome) + \
-                np.sum(phenome ** 2 - self.a * np.cos(2 * np.pi * phenome))
+        if isinstance(individual.phenome, np.ndarray):
+            return self.a * len(individual.phenome) + \
+                np.sum(individual.phenome ** 2 - self.a * np.cos(2 * np.pi * individual.phenome))
         return self.a * \
-            len(phenome) + sum([x ** 2 - self.a *
-                                np.cos(2 * np.pi * x) for x in phenome])
+            len(individual.phenome) + sum([x ** 2 - self.a *
+                                np.cos(2 * np.pi * x) for x in individual.phenome])
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -191,25 +192,25 @@ class RosenbrockProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> phenome = [0.5, -0.2, 0.1]
-        >>> RosenbrockProblem().evaluate(phenome)
+        >>> RosenbrockProblem().evaluate(Individual(phenome))
         22.3
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        if isinstance(phenome, np.ndarray):
-            x_p = phenome[1:]
-            x = phenome[:-1]
+        if isinstance(individual.phenome, np.ndarray):
+            x_p = individual.phenome[1:]
+            x = individual.phenome[:-1]
             return np.sum(100 * (x_p - x ** 2) ** 2 + (x - 1) ** 2)
 
         sum = 0
-        for i, x in enumerate(phenome[0:-1]):
-            x_p = phenome[i + 1]
+        for i, x in enumerate(individual.phenome[0:-1]):
+            x_p = individual.phenome[i + 1]
             sum += 100 * (x_p - x ** 2) ** 2 + (x - 1) ** 2
         return sum
 
@@ -269,19 +270,19 @@ class StepProblem(ScalarProblem):
     def __init__(self, maximize=True):
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> import numpy as np
         >>> phenome = np.array([3.5, -3.8, 5.0])
-        >>> StepProblem().evaluate(phenome)
+        >>> StepProblem().evaluate(Individual(phenome))
         4.0
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        return np.sum(np.floor(phenome))
+        return np.sum(np.floor(individual.phenome))
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -336,21 +337,21 @@ class NoisyQuarticProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued list phenome (the output varies, since the function has noise):
 
         >>> phenome = [3.5, -3.8, 5.0]
-        >>> r = NoisyQuarticProblem().evaluate(phenome)
+        >>> r = NoisyQuarticProblem().evaluate(Individual(phenome))
         >>> print(f'Result: {r}')
         Result: ...
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        indices = np.arange(len(phenome)) + 1
-        noise = np.random.normal(0, 1, len(phenome))
-        return np.dot(indices, np.power(phenome, 4)) + np.sum(noise)
+        indices = np.arange(len(individual.phenome)) + 1
+        noise = np.random.normal(0, 1, len(individual.phenome))
+        return np.dot(indices, np.power(individual.phenome, 4)) + np.sum(noise)
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -431,18 +432,18 @@ class ShekelProblem(ScalarProblem):
         self.k = k
         self.c = c
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued list phenome (the output varies, since the function has noise).
 
         :param phenome: real-valued to be evaluated
         :returns: its fitness
         """
-        assert (len(phenome) == 2)
+        assert (len(individual.phenome) == 2)
 
         def f(j):
-            return self.c[j] + (phenome[0] - self.points[0][j]
-                                ) ** 6 + (phenome[1] - self.points[1][j]) ** 6
+            return self.c[j] + (individual.phenome[0] - self.points[0][j]
+                                ) ** 6 + (individual.phenome[1] - self.points[1][j]) ** 6
 
         return 1 / (1 / self.k + np.sum([1 / f(j) for j in range(25)]))
 
@@ -505,19 +506,19 @@ class GriewankProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        t1 = np.sum(np.power(phenome, 2) / 4000)
-        i_vector = np.sqrt(np.arange(1, len(phenome) + 1))
-        t2 = np.prod(np.cos(phenome / i_vector))
+                              f"Got {type(individual.phenome)}."))
+        t1 = np.sum(np.power(individual.phenome, 2) / 4000)
+        i_vector = np.sqrt(np.arange(1, len(individual.phenome) + 1))
+        t2 = np.prod(np.cos(individual.phenome / i_vector))
         return t1 - t2 + 1
 
     def __str__(self):
@@ -563,20 +564,20 @@ class AckleyProblem(ScalarProblem):
         self.b = b
         self.c = c
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        d = len(phenome)
+                              f"Got {type(individual.phenome)}."))
+        d = len(individual.phenome)
         t1 = -self.a * np.exp(-self.b * np.sqrt(1.0 /
-                                                d * np.sum(np.power(phenome, 2))))
-        t2 = np.exp(1.0 / d * np.sum(np.cos(self.c * phenome)))
+                                                d * np.sum(np.power(individual.phenome, 2))))
+        t2 = np.exp(1.0 / d * np.sum(np.cos(self.c * individual.phenome)))
         return t1 - t2 + self.a + np.e
 
     def __str__(self):
@@ -624,18 +625,18 @@ class WeierstrassProblem(ScalarProblem):
         self.a = a
         self.b = b
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
+                              f"Got {type(individual.phenome)}."))
         result = 0
-        for x in phenome:
+        for x in individual.phenome:
             t1 = 0
             for k in range(self.kmax):
                 t1 += self.a ** k * \
@@ -646,7 +647,7 @@ class WeierstrassProblem(ScalarProblem):
         for k in range(self.kmax):
             t2 += self.a ** k * np.cos(np.pi * (self.b ** k))
 
-        result = result - len(phenome) * t2
+        result = result - len(individual.phenome) * t2
         return result
 
     def __str__(self):
@@ -722,25 +723,25 @@ class LangermannProblem(ScalarProblem):
             raise ValueError(
                 f"Got a value of shape {self.a.shape} for 'a', but must be a {m}xd matrix.")
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        assert (phenome is not None)
-        if not isinstance(phenome, np.ndarray):
+        assert (individual.phenome is not None)
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        if len(phenome) != self.a.shape[1]:
+                              f"Got {type(individual.phenome)}."))
+        if len(individual.phenome) != self.a.shape[1]:
             raise ValueError(
-                f"Received an {len(phenome)}-dimensional phenome, but this is a {self.a.shape[1]}-dimensional Langerman function.")
+                f"Received an {len(individual.phenome)}-dimensional phenome, but this is a {self.a.shape[1]}-dimensional Langerman function.")
         result = 0
         for i in range(self.m):
             result -= self.c[i] * np.exp(
-                -1.0 / np.pi * np.sum((phenome - self.a[i]) ** 2)) \
-                      * np.cos(np.pi * np.sum((phenome - self.a[i]) ** 2))
+                -1.0 / np.pi * np.sum((individual.phenome - self.a[i]) ** 2)) \
+                      * np.cos(np.pi * np.sum((individual.phenome - self.a[i]) ** 2))
         return result
 
     def __str__(self):
@@ -819,24 +820,24 @@ class LunacekProblem(ScalarProblem):
         self.mu_2 = mu_2 if mu_2 is not None else - \
             np.sqrt((mu_1**2 - d) / self.s)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        assert(phenome is not None)
-        if len(phenome) != self.N:
+        assert(individual.phenome is not None)
+        if len(individual.phenome) != self.N:
             warnings.warn(
-                f"Phenome has length {len(phenome)}, but this function expected {self.N}-dimensional input.")
-        if not isinstance(phenome, np.ndarray):
+                f"Phenome has length {len(individual.phenome)}, but this function expected {self.N}-dimensional input.")
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        sphere1 = np.sum((phenome - self.mu_1)**2)
-        sphere2 = self.d * len(phenome) + self.s * \
-            np.sum((phenome - self.mu_2)**2)
-        sinusoid = 10 * np.sum(1 - np.cos(2 * np.pi * (phenome - self.mu_1)))
+                              f"Got {type(individual.phenome)}."))
+        sphere1 = np.sum((individual.phenome - self.mu_1)**2)
+        sphere2 = self.d * len(individual.phenome) + self.s * \
+            np.sum((individual.phenome - self.mu_2)**2)
+        sinusoid = 10 * np.sum(1 - np.cos(2 * np.pi * (individual.phenome - self.mu_1)))
         return min(sphere1, sphere2) + sinusoid
 
     def __str__(self):
@@ -883,20 +884,20 @@ class SchwefelProblem(ScalarProblem):
         super().__init__(maximize)
         self.alpha = alpha
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
-        :param phenome: real-valued vector to be evaluated
+        :param individual: individual with a real-valued phenome to be evaluated
         :returns: its fitness.
         """
-        assert(phenome is not None)
-        if not isinstance(phenome, np.ndarray):
+        assert(individual.phenome is not None)
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
+                              f"Got {type(individual.phenome)}."))
 
-        return np.sum(-phenome * np.sin(np.sqrt(np.abs(phenome)))
-                      ) + self.alpha * len(phenome)
+        return np.sum(-individual.phenome * np.sin(np.sqrt(np.abs(individual.phenome)))
+                      ) + self.alpha * len(individual.phenome)
 
     def __str__(self):
         """Returns the name of the class.
@@ -936,14 +937,14 @@ class GaussianProblem(ScalarProblem):
         self.width = 1
         self.height = 1
 
-    def evaluate(self, phenome):
-        assert(phenome is not None)
+    def evaluate(self, individual):
+        assert(individual.phenome is not None)
 
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
+                              f"Got {type(individual.phenome)}."))
 
-        return self.height * np.exp(-np.sum(np.power(phenome/self.width, 2)))
+        return self.height * np.exp(-np.sum(np.power(individual.phenome/self.width, 2)))
 
     def __str__(self):
         """Returns the name of the class.
@@ -1013,20 +1014,20 @@ class CosineFamilyProblem(ScalarProblem):
         self.global_optima_counts = np.array(global_optima_counts)
         self.local_optima_counts = np.array(local_optima_counts)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Computes the function value from a real-valued phenome.
 
-        :param phenome: real-valued vector to be evaluated
+        :param phenome: individual with a real-valued phenome vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        term1 = -np.cos((self.global_optima_counts - 1) * 2 * np.pi * phenome)
+                              f"Got {type(individual.phenome)}."))
+        term1 = -np.cos((self.global_optima_counts - 1) * 2 * np.pi * individual.phenome)
         term2 = - self.alpha * \
             np.cos((self.global_optima_counts - 1) * 2 *
-                   np.pi * self.local_optima_counts * phenome)
+                   np.pi * self.local_optima_counts * individual.phenome)
         value = np.sum(term1 + term2) / (2 * self.dimensions)
         return value
 
@@ -1140,8 +1141,8 @@ class QuadraticFamilyProblem(ScalarProblem):
     def dimensions(self):
         return len(self.offset_vectors[0])
         
-    def evaluate(self, phenome):
-        basin_values = [ p.evaluate(phenome) for p in self.parabaloids ]
+    def evaluate(self, individual):
+        basin_values = [ p.evaluate(individual.phenome) for p in self.parabaloids ]
         return np.min(basin_values)
 
     @classmethod
@@ -1228,8 +1229,8 @@ class ParabaloidProblem(ScalarProblem):
         # Construct the matrix for the quadratic form
         self.matrix = R.T @ D @ R
 
-    def evaluate(self, phenome):
-        return phenome.T @ self.matrix @ phenome
+    def evaluate(self, individual):
+        return individual.phenome.T @ self.matrix @ individual.phenome
 
 
 ##############################
@@ -1297,7 +1298,7 @@ class TranslatedProblem(ScalarProblem):
         offset = np.random.uniform(min_offset, max_offset, dimensions)
         return cls(problem, offset, maximize=maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Evaluate the fitness of a point after translating the fitness function.
 
@@ -1307,20 +1308,20 @@ class TranslatedProblem(ScalarProblem):
         >>> offset = [-1.0, -1.0, 1.0, 1.0, -5.0]
         >>> t_sphere = TranslatedProblem(SpheroidProblem(), offset)
         >>> genome = np.array([0.5, 2.0, 3.0, 8.5, -0.6])
-        >>> t_sphere.evaluate(genome)
+        >>> t_sphere.evaluate(Individual(genome))
         90.86
         """
-        assert (len(phenome) == len(self.offset)), \
-            f"Tried to evalute a {len(phenome)}-D genome in a " \
+        assert (len(individual.phenome) == len(self.offset)), \
+            f"Tried to evalute a {len(individual.phenome)}-D genome in a " \
             f"{len(self.offset)}-D fitness function. "
         # Substract the offset so that we are moving the origin *to* the offset.
         # This way we can think of it as offsetting the fitness function,
         # rather than the input points.
-        if not isinstance(phenome, np.ndarray):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
-        new_phenome = phenome - self.offset
-        return self.problem.evaluate(new_phenome)
+                              f"Got {type(individual.phenome)}."))
+        new_phenome = individual.phenome - self.offset
+        return self.problem.evaluate(Individual(new_phenome))
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1350,16 +1351,16 @@ class ScaledProblem(ScalarProblem):
         self.old_bounds = problem.bounds
         self.bounds = new_bounds
 
-    def evaluate(self, phenome):
-        if not isinstance(phenome, np.ndarray):
+    def evaluate(self, individual):
+        if not isinstance(individual.phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(phenome)}."))
+                              f"Got {type(individual.phenome)}."))
         transformed_phenome = self.old_bounds[0] + (
-                    phenome - self.bounds[0]) / (
+                    individual.phenome - self.bounds[0]) / (
                                           self.bounds[1] - self.bounds[0]) \
                               * (self.old_bounds[1] - self.old_bounds[0])
-        assert (len(transformed_phenome) == len(phenome))
-        return self.problem.evaluate(transformed_phenome)
+        assert (len(transformed_phenome) == len(individual.phenome))
+        return self.problem.evaluate(Individual(transformed_phenome))
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1516,7 +1517,7 @@ class MatrixTransformedProblem(ScalarProblem):
         matrix = random_orthonormal_matrix(dimensions)
         return cls(problem, matrix, maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         """
         Evaluated the fitness of a point on the transformed fitness landscape.
 
@@ -1525,7 +1526,7 @@ class MatrixTransformedProblem(ScalarProblem):
 
         >>> import numpy as np
         >>> s = TranslatedProblem(SpheroidProblem(), offset=[0, 1])
-        >>> round(s.evaluate(np.array([0, 1])), 5)
+        >>> round(s.evaluate(Individual(np.array([0, 1]))), 5)
         0
 
         Now let's take a rotation matrix that transforms the space by pi/2
@@ -1539,19 +1540,19 @@ class MatrixTransformedProblem(ScalarProblem):
 
         The rotation has moved the new global optimum to (1, 0)
 
-        >>> round(r.evaluate(np.array([1, 0])), 5)
+        >>> round(r.evaluate(Individual(np.array([1, 0]))), 5)
         0.0
 
         The point (0, 1) lies at a distance of sqrt(2) from the new optimum,
         and has a fitness of 2:
 
-        >>> round(r.evaluate(np.array([0, 1])), 5)
+        >>> round(r.evaluate(Individual(np.array([0, 1]))), 5)
         2.0
         """
-        assert (len(phenome) == len(
-            self.matrix)), f"Tried to evalute a {len(phenome)}-D genome in a " \
+        assert (len(individual.phenome) == len(
+            self.matrix)), f"Tried to evalute a {len(individual.phenome)}-D genome in a " \
                            f"{len(self.matrix)}-D fitness function. "
-        new_point = np.matmul(self.matrix, phenome)
+        new_point = np.matmul(self.matrix, individual.phenome)
         return self.problem.evaluate(new_point)
 
     def __str__(self):
@@ -1626,7 +1627,7 @@ def plot_2d_problem(problem, xlim=None, ylim=None, kind='surface',
     """
 
     def call(phenome):
-        return problem.evaluate(phenome)
+        return problem.evaluate(Individual(phenome))
 
     if xlim is None:
         xlim = problem.bounds

--- a/leap_ec/real_rep/problems.py
+++ b/leap_ec/real_rep/problems.py
@@ -1321,7 +1321,10 @@ class TranslatedProblem(ScalarProblem):
             raise ValueError(("Expected phenome to be a numpy array. "
                               f"Got {type(individual.phenome)}."))
         new_phenome = individual.phenome - self.offset
-        return self.problem.evaluate(Individual(new_phenome))
+
+        new_ind = individual.clone()
+        new_ind.phenome = new_phenome
+        return self.problem.evaluate(new_ind)
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1360,7 +1363,10 @@ class ScaledProblem(ScalarProblem):
                                           self.bounds[1] - self.bounds[0]) \
                               * (self.old_bounds[1] - self.old_bounds[0])
         assert (len(transformed_phenome) == len(individual.phenome))
-        return self.problem.evaluate(Individual(transformed_phenome))
+
+        transformed_ind = individual.clone()
+        transformed_ind.phenome = transformed_phenome
+        return self.problem.evaluate(transformed_ind)
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1553,7 +1559,9 @@ class MatrixTransformedProblem(ScalarProblem):
             self.matrix)), f"Tried to evalute a {len(individual.phenome)}-D genome in a " \
                            f"{len(self.matrix)}-D fitness function. "
         new_point = np.matmul(self.matrix, individual.phenome)
-        return self.problem.evaluate(new_point)
+        new_ind = individual.clone()
+        new_ind.phenome = new_point
+        return self.problem.evaluate(new_ind)
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class

--- a/tests/real_rep/test_problems.py
+++ b/tests/real_rep/test_problems.py
@@ -2,6 +2,7 @@
 import numpy as np
 from pytest import approx
 
+from leap_ec import Individual
 from leap_ec.real_rep import problems
 
 
@@ -16,7 +17,7 @@ def test_GriewankProblem_eval():
     expected = t[0]**2/4000 + t[1]**2/4000 - np.cos(t[0]/np.sqrt(1))*np.cos(t[1]/np.sqrt(2)) + 1
 
     p = problems.GriewankProblem()
-    assert(approx(expected) == p.evaluate(t))
+    assert(approx(expected) == p.evaluate(Individual(t)))
 
 
 
@@ -29,5 +30,5 @@ def test_WeierstrassProblem_eval():
     """
     p = problems.WeierstrassProblem()
 
-    assert(approx(0) == p.evaluate(np.array([0, 0])))
-    assert(approx(0) == p.evaluate(np.array([0]*25)))
+    assert(approx(0) == p.evaluate(Individual(np.array([0, 0]))))
+    assert(approx(0) == p.evaluate(Individual(np.array([0]*25))))

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -39,7 +39,7 @@ class BrokenProblem(leap_ec.problem.ScalarProblem):
     def __init__(self, maximize):
         super().__init__(maximize)
 
-    def evaluate(self, phenome):
+    def evaluate(self, individual):
         raise RuntimeError('Simulated exception')
 
 

--- a/tests/test_inc_generation.py
+++ b/tests/test_inc_generation.py
@@ -7,7 +7,7 @@ from leap_ec.util import inc_generation
 def test_inc_generation():
     """ Test the inc_generation() function.
     """
-    my_inc_generation = inc_generation(context)
+    my_inc_generation = inc_generation(context=context)
 
     # The core context is set to the current generation, which will start as zero
     assert context['leap']['generation'] == 0
@@ -34,7 +34,7 @@ def test_inc_generation_callbacks():
     def callback(new_generation):
         assert new_generation == 1
 
-    my_inc_generation = inc_generation(context, callbacks=[callback])
+    my_inc_generation = inc_generation(context=context, callbacks=[callback])
 
     # Incremented the generation should call our test callback
     my_inc_generation()

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -1,10 +1,10 @@
 """Unit tests for the leap_ec.problem module."""
-from leap_ec import problem
-from leap_ec.real_rep import problems as real_prob
-
 import numpy as np
 import pytest
 from scipy.stats import norm
+
+from leap_ec import Individual, problem
+from leap_ec.real_rep import problems as real_prob
 
 
 ##############################
@@ -24,7 +24,7 @@ def test_averagefitnessproblem():
                     wrapped_problem = real_prob.NoisyQuarticProblem(),
                     n = n)
     x = [ 1, 1, 1, 1 ]
-    y = p.evaluate(x)
+    y = p.evaluate(Individual(x))
 
     # The value of the noisy-quartic is sum(i*x**4) plus additive Gaussian noise
     expected_mean = 10.0  # = 1 + 2 + 3 + 4 


### PR DESCRIPTION
This PR resolves #191, refactoring all of our `Problem` classes and code that calls them to define fitness functions over `Individual` instances, instead of over phenome generated by calls to `individual.decode()`.

Just looking for a sanity check from @markcoletti, since this is a big refactor & API change.

Summary of changes:
 - Basically, to compute fitness values, all of our `Problem` implementations now reach into the `Individual` by calling `individual.phenome`.
 - To support this, I added a property to `Individual` that will compute the `phenome` if it hasn't been computed already when `individual.phenome` is accessed.
 - Importantly, however, `individual.evaluate()` still always re-computes the `phenome` by calling `self.decode()`, even if the `phenome` already exists.  This ensures that phenomes are always updated when we recompute fitness (ex. in cloned/mutated individuals).
 - Aside, this PR also fixes API issues with `inc_generation()` and `genome_mutate_gaussian()` that I encountered while trying to get tests & notebooks to pass (both fall-out from when we added new arguments to their interfaces some moons ago).