### PR TITLE
Feature/issue 193 problem

### DIFF
--- a/examples/advanced/coevolution_via_fitness_functions.py
+++ b/examples/advanced/coevolution_via_fitness_functions.py
@@ -22,6 +22,7 @@ from leap_ec.algorithm import multi_population_ea
 from leap_ec.binary_rep.problems import MaxOnes
 from leap_ec.binary_rep.initializers import create_binary_sequence
 from leap_ec.binary_rep.ops import mutate_bitflip
+from leap_ec.individual import WholeEvaluatedIndividual
 from leap_ec.problem import CooperativeProblem
 
 
@@ -33,7 +34,8 @@ def get_representation(length: int):
     binary sequences of the given length."""
     assert(length > 0)
     return Representation(
-        initialize=create_binary_sequence(length)
+        initialize=create_binary_sequence(length),
+        individual_cls=WholeEvaluatedIndividual
     )
 
 

--- a/examples/advanced/external_simulation.py
+++ b/examples/advanced/external_simulation.py
@@ -94,7 +94,7 @@ for phenome_str in sys.stdin:
                             
                             # By default, the initial population would be evaluated one-at-a-time.
                             # Passing group_evaluate into init_evaluate evaluates the population in batches.
-                            init_evaluate=ops.grouped_evaluate(problem=problem, max_individuals_per_chunk=max_individuals_per_chunk),
+                            init_evaluate=ops.grouped_evaluate(max_individuals_per_chunk=max_individuals_per_chunk),
 
                             # Representation
                             representation=Representation(

--- a/leap_ec/binary_rep/problems.py
+++ b/leap_ec/binary_rep/problems.py
@@ -32,16 +32,14 @@ class MaxOnes(ScalarProblem):
         super().__init__(maximize)
         self.target_string = target_string
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         By default this counts the number of 1's:
 
         >>> from leap_ec.individual import Individual
         >>> import numpy as np
         >>> p = MaxOnes()
-        >>> ind = Individual(np.array([0, 0, 1, 1, 0, 1, 0, 1, 1]),
-        ...                   problem=p)
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([0, 0, 1, 1, 0, 1, 0, 1, 1]))
         5
 
         Or, if a target string was given, we count matches:
@@ -49,20 +47,18 @@ class MaxOnes(ScalarProblem):
         >>> from leap_ec.individual import Individual
         >>> import numpy as np
         >>> p = MaxOnes(target_string=np.array([1, 1, 1, 1, 1, 0, 0, 0 ,0]))
-        >>> ind = Individual(np.array([0, 0, 1, 1, 0, 1, 0, 1, 1]),
-        ...                   problem=p)
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([0, 0, 1, 1, 0, 1, 0, 1, 1]))
         3
         """
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
+                              f"Got {type(phenome)}."))
         # If we've 
         if self.target_string is not None:
-            assert(len(individual.phenome) == len(self.target_string)), f"Fitness function target string has {len(self.target_string)} dimensions, but received a phenome with {len(individual.phenome)} dimensions."
-            return np.sum(individual.phenome == self.target_string)
+            assert(len(phenome) == len(self.target_string)), f"Fitness function target string has {len(self.target_string)} dimensions, but received a phenome with {len(individual.phenome)} dimensions."
+            return np.sum(phenome == self.target_string)
         else:
-            return np.count_nonzero(individual.phenome == 1)
+            return np.count_nonzero(phenome == 1)
 
 
 ##############################
@@ -89,38 +85,31 @@ class LeadingOnes(ScalarProblem):
         super().__init__(maximize)
         self.target_string = target_string
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         By default this counts the number of consecutive 1's at the
         start of the string:
 
-        >>> from leap_ec.individual import Individual
         >>> import numpy as np
         >>> p = LeadingOnes()
-        >>> ind = Individual(np.array([1, 1, 1, 1, 0, 1, 0, 1, 1]),
-        ...                   problem=p)
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([1, 1, 1, 1, 0, 1, 0, 1, 1]))
         4
 
         Or, if a target string was given, we count matches:
 
-        >>> from leap_ec.individual import Individual
-        >>> import numpy as np
         >>> p = LeadingOnes(target_string=np.array([1, 1, 0, 1, 1, 0, 0, 0 ,0]))
-        >>> ind = Individual(np.array([1, 1, 1, 1, 0, 1, 0, 1, 1]),
-        ...                   problem=p)
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([1, 1, 1, 1, 0, 1, 0, 1, 1]))
         2
         """
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
+                              f"Got {type(phenome)}."))
         
         if self.target_string is not None:
-            assert(len(individual.phenome) == len(self.target_string)), f"Fitness function target string has {len(self.target_string)} dimensions, but received a phenome with {len(individual.phenome)} dimensions."
-            match_str = (individual.phenome == self.target_string)
+            assert(len(phenome) == len(self.target_string)), f"Fitness function target string has {len(self.target_string)} dimensions, but received a phenome with {len(individual.phenome)} dimensions."
+            match_str = (phenome == self.target_string)
         else:
-            match_str = (individual.phenome == 1)
+            match_str = (phenome == 1)
 
         groups = groupby(match_str)
         _, leading_vals = next(groups)
@@ -140,32 +129,28 @@ class DeceptiveTrap(ScalarProblem):
     def __init__(self, maximize=True):
         super().__init__(maximize=maximize)
     
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         
         """
-        >>> from leap_ec.individual import Individual
         >>> import numpy as np
         >>> p = DeceptiveTrap()
 
         The trap function has a global maximum when the number of one's
         is maximized:
 
-        >>> ind = Individual(np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]))
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1]))
         10
 
         It's minimized when we have just one zero:
-        >>> ind = Individual(np.array([1, 1, 1, 1, 0, 1, 1, 1, 1, 1]))
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([1, 1, 1, 1, 0, 1, 1, 1, 1, 1]))
         0
 
         And has a local optimum when we have no ones at all:
-        >>> ind = Individual(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]))
         9
         """
-        dimensions = len(individual.phenome)
-        max_ones = np.count_nonzero(individual.phenome == 1)
+        dimensions = len(phenome)
+        max_ones = np.count_nonzero(phenome == 1)
         if max_ones == dimensions:
             return dimensions
         else:
@@ -185,27 +170,24 @@ class TwoMax(ScalarProblem):
     def __init__(self, maximize=True):
         super().__init__(maximize=maximize)
     
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         
         """
-        >>> from leap_ec.individual import Individual
         >>> import numpy as np
         >>> p = TwoMax()
 
         The TwoMax problems returns the number over 1's if they are
         in the majority:
 
-        >>> ind = Individual(np.array([1, 1, 1, 1, 1, 1, 1, 0, 0, 0]))
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([1, 1, 1, 1, 1, 1, 1, 0, 0, 0]))
         7
 
         Else the number of zeros:
-        >>> ind = Individual(np.array([0, 0, 0, 1, 0, 0, 0, 1, 1, 1]))
-        >>> p.evaluate(ind)
+        >>> p.evaluate(np.array([0, 0, 0, 1, 0, 0, 0, 1, 1, 1]))
         6
         """
-        dimensions = len(individual.phenome)
-        max_ones = np.count_nonzero(individual.phenome == 1)
+        dimensions = len(phenome)
+        max_ones = np.count_nonzero(phenome == 1)
         return int(np.abs(dimensions/2 - max_ones) + dimensions/2)
 
 
@@ -229,9 +211,9 @@ class ImageProblem(ScalarProblem):
         x = ImageOps.fit(x, size)
         return x.convert('1')
 
-    def evaluate(self, individual):
-        assert (len(individual.phenome) == len(self.flat_img)
-                ), f"Bad genome length: got {len(individual.phenome)}, expected " \
+    def evaluate(self, phenome):
+        assert (len(phenome) == len(self.flat_img)
+                ), f"Bad genome length: got {len(phenome)}, expected " \
                    f"{len(self.flat_img)} "
-        diff = np.logical_not(individual.phenome ^ self.flat_img)
+        diff = np.logical_not(phenome ^ self.flat_img)
         return sum(diff)

--- a/leap_ec/executable_rep/problems.py
+++ b/leap_ec/executable_rep/problems.py
@@ -89,10 +89,10 @@ class EnvironmentProblem(ScalarProblem):
             # Otherwise just look at the shape of the space directly
             return int(np.prod(observation_space.shape))
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """Run the environmental simulation using `executable` phenotype as a controller,
         and use the resulting observations & rewards to compute a fitness value."""
-        executable = individual.phenome
+        executable = phenome
         observations = []
         rewards = []
         for r in range(self.runs):
@@ -136,7 +136,7 @@ class TruthTableProblem(ScalarProblem):
         self.pad_inputs = pad_inputs
         self.name = name
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Say our object function is $(x_0 \wedge x_1) \vee x_3$:
 
@@ -174,7 +174,7 @@ class TruthTableProblem(ScalarProblem):
         1.0
 
         """
-        executable = individual.phenome
+        executable = phenome
         assert(executable is not None)
         assert(callable(executable))
         input_samples = self._enumerate_tt(self.num_inputs)
@@ -238,8 +238,8 @@ class ImageXYProblem(ScalarProblem):
         fast_output = np.stack(fast_output, axis=1).astype(int)
         return fast_output
 
-    def evaluate(self, individual):
-        executable = individual.phenome
+    def evaluate(self, phenome):
+        executable = phenome
         assert(executable is not None)
         assert(callable(executable))
         # Collect the target image into an array

--- a/leap_ec/executable_rep/problems.py
+++ b/leap_ec/executable_rep/problems.py
@@ -162,7 +162,7 @@ class TruthTableProblem(ScalarProblem):
         $7/8 = 0.875$:
         
         >>> from leap_ec import Individual
-        >>> problem.evaluate(Individual(executable))
+        >>> problem.evaluate(executable)
         0.875
 
         Note that we our lambda functions above return a list that contains a 
@@ -170,7 +170,7 @@ class TruthTableProblem(ScalarProblem):
         this framework allows us to work with functions of more than one output:
 
         >>> problem = TruthTableProblem(lambda x: [ x[0] and x[1], x[0] or x[1] ], num_inputs=3, num_outputs=2)
-        >>> problem.evaluate(Individual(lambda x: [ x[0] and x[1], x[0] or x[1] ]))
+        >>> problem.evaluate(lambda x: [ x[0] and x[1], x[0] or x[1] ])
         1.0
 
         """

--- a/leap_ec/individual.py
+++ b/leap_ec/individual.py
@@ -288,3 +288,35 @@ class RobustIndividual(Individual):
         # *return* it to give more options to the programmer for using the
         # newly evaluated fitness.
         return self.fitness
+
+
+##############################
+# WholeEvalautedIndividual
+##############################
+class WholeEvaluatedIndividual(Individual):
+    """An Individual that, when evaluated, passes its whole self
+    to the evaluation function, rather than just its phenome.
+    
+    In most applications, fitness evaluation requires only phenome
+    information, so that is all that we pass from the Individual to the
+    Problem.  This is important, because during distributed evaluation,
+    we want to pass as little information as possible across nodes.
+
+    WholeEvaluatedIndividual is used for special cases where fitness
+    evaluation needs access to more information about an individual than
+    its phenome.  This is strange in most cases and should be avoided,
+    but can make certain algorithms more elegant (ex. it's helpful when
+    interpretting cooperative coevolution as an island model).
+    
+    This can dramatically slow down distributed evaluation (i.e. with dask)
+    in some applications—use with caution.
+    """
+    def evaluate_imp(self):
+        """ This is the evaluate 'implementation' called by
+            self.evaluate().   It's intended to be optionally over-ridden by
+            sub-classes to give an opportunity to pass in ancillary data to
+            the evaluate process either by tailoring the problem interface or
+            that of the given decoder.
+        """
+        self.decode()
+        return self.problem.evaluate(self.phenome, individual=self)

--- a/leap_ec/individual.py
+++ b/leap_ec/individual.py
@@ -157,7 +157,7 @@ class Individual:
             that of the given decoder.
         """
         self.decode()
-        return self.problem.evaluate(self)
+        return self.problem.evaluate(self.phenome)
 
     def evaluate(self):
         """ determine this individual's fitness

--- a/leap_ec/ops.py
+++ b/leap_ec/ops.py
@@ -288,7 +288,7 @@ def grouped_evaluate(population: list, max_individuals_per_chunk: int = None) ->
 
     fitnesses = []
     for chunk in chunks(population, max_individuals_per_chunk):
-        fit = problem.evaluate_multiple(chunk)
+        fit = problem.evaluate_multiple([c.phenome for c in chunk])
         fitnesses.extend(fit)
 
     for fit, ind in zip(fitnesses, population):

--- a/leap_ec/ops.py
+++ b/leap_ec/ops.py
@@ -288,7 +288,9 @@ def grouped_evaluate(population: list, max_individuals_per_chunk: int = None) ->
 
     fitnesses = []
     for chunk in chunks(population, max_individuals_per_chunk):
-        fit = problem.evaluate_multiple([c.phenome for c in chunk])
+        # XXX Always passing individuals along to the problem.
+        #     Does this create problems with dask, even when we aren't using individuals?
+        fit = problem.evaluate_multiple([c.phenome for c in chunk], individuals=chunk)
         fitnesses.extend(fit)
 
     for fit, ind in zip(fitnesses, population):

--- a/leap_ec/probe.py
+++ b/leap_ec/probe.py
@@ -835,7 +835,7 @@ class CartesianPhenotypePlotProbe:
             @np.vectorize
             def v_fun(x, y):
                 phenome = np.concatenate((np.hstack((x,y)), pad))
-                return contours.evaluate(Individual(phenome))
+                return contours.evaluate(phenome)
 
             if granularity is None:
                 granularity = (contours.bounds[1] - contours.bounds[0]) / 50.
@@ -1092,7 +1092,7 @@ class SumPhenotypePlotProbe:
             x = np.arange(int(xlim[0]), max_number_of_ones + 1, int(granularity))
             
             # Now plot the function over them
-            y = np.array([ problem.evaluate(Individual(bitstring_with_ones(i))) for i in x ])
+            y = np.array([ problem.evaluate(bitstring_with_ones(i)) for i in x ])
             ax.plot(x, y, color='black', linewidth=3)
 
         self.sc = ax.scatter([], [])

--- a/leap_ec/problem.py
+++ b/leap_ec/problem.py
@@ -221,7 +221,7 @@ class ExternalProcessProblem(ScalarProblem):
         assert(len(fitnesses) == 1)
         return fitnesses[0]
     
-    def evaluate_multiple(self, phenomes):
+    def evaluate_multiple(self, phenomes, *args, **kwargs):
         # Convert the phenomes into one big string
         def phenome_to_str(p):
             return ','.join([ str(x) for x in p ])
@@ -483,6 +483,14 @@ class CooperativeProblem(Problem):
             fitnesses.append(fitness)
 
         return np.mean(fitnesses)
+
+    def evaluate_multiple(self, phenomes, individuals):
+        """Evaluate multiple phenomes all at once, returning a list of fitness
+        values.
+        
+        By default this just calls `self.evaluate()` multiple times.  Override this
+        if you need to, say, send a group of individuals off to parallel """
+        return [ self.evaluate(p, individual=i) for p, i in zip(phenomes, individuals) ]
 
     def _choose_collaborators(self, current_genome, current_subpop_index, subpopulations):
         """Choose collaborators from the subpopulations, returning a list that contains

--- a/leap_ec/real_rep/problems.py
+++ b/leap_ec/real_rep/problems.py
@@ -47,20 +47,20 @@ class SpheroidProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> phenome = [0.5, 0.8, 1.5]
-        >>> SpheroidProblem().evaluate(Individual(phenome))
+        >>> SpheroidProblem().evaluate(phenome)
         3.14
 
         :param phenome: real-valued vector to be evaluated
         :return: it's fitness, `sum(phenome**2)`
         """
-        if isinstance(individual.phenome, np.ndarray):
-            return np.sum(individual.phenome ** 2)
-        return sum([x ** 2 for x in individual.phenome])
+        if isinstance(phenome, np.ndarray):
+            return np.sum(phenome ** 2)
+        return sum([x ** 2 for x in phenome])
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -120,23 +120,23 @@ class RastriginProblem(ScalarProblem):
         super().__init__(maximize)
         self.a = a
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> phenome = [1.0/12, 0]
-        >>> RastriginProblem().evaluate(Individual(phenome)) # doctest: +ELLIPSIS
+        >>> RastriginProblem().evaluate(phenome) # doctest: +ELLIPSIS
         0.1409190406...
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        if isinstance(individual.phenome, np.ndarray):
-            return self.a * len(individual.phenome) + \
-                np.sum(individual.phenome ** 2 - self.a * np.cos(2 * np.pi * individual.phenome))
+        if isinstance(phenome, np.ndarray):
+            return self.a * len(phenome) + \
+                np.sum(phenome ** 2 - self.a * np.cos(2 * np.pi * phenome))
         return self.a * \
-            len(individual.phenome) + sum([x ** 2 - self.a *
-                                np.cos(2 * np.pi * x) for x in individual.phenome])
+            len(phenome) + sum([x ** 2 - self.a *
+                                np.cos(2 * np.pi * x) for x in phenome])
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -192,25 +192,25 @@ class RosenbrockProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> phenome = [0.5, -0.2, 0.1]
-        >>> RosenbrockProblem().evaluate(Individual(phenome))
+        >>> RosenbrockProblem().evaluate(phenome)
         22.3
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        if isinstance(individual.phenome, np.ndarray):
-            x_p = individual.phenome[1:]
-            x = individual.phenome[:-1]
+        if isinstance(phenome, np.ndarray):
+            x_p = phenome[1:]
+            x = phenome[:-1]
             return np.sum(100 * (x_p - x ** 2) ** 2 + (x - 1) ** 2)
 
         sum = 0
-        for i, x in enumerate(individual.phenome[0:-1]):
-            x_p = individual.phenome[i + 1]
+        for i, x in enumerate(phenome[0:-1]):
+            x_p = phenome[i + 1]
             sum += 100 * (x_p - x ** 2) ** 2 + (x - 1) ** 2
         return sum
 
@@ -270,19 +270,19 @@ class StepProblem(ScalarProblem):
     def __init__(self, maximize=True):
         super().__init__(maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued list phenome:
 
         >>> import numpy as np
         >>> phenome = np.array([3.5, -3.8, 5.0])
-        >>> StepProblem().evaluate(Individual(phenome))
+        >>> StepProblem().evaluate(phenome)
         4.0
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        return np.sum(np.floor(individual.phenome))
+        return np.sum(np.floor(phenome))
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -337,21 +337,21 @@ class NoisyQuarticProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued list phenome (the output varies, since the function has noise):
 
         >>> phenome = [3.5, -3.8, 5.0]
-        >>> r = NoisyQuarticProblem().evaluate(Individual(phenome))
+        >>> r = NoisyQuarticProblem().evaluate(phenome)
         >>> print(f'Result: {r}')
         Result: ...
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness
         """
-        indices = np.arange(len(individual.phenome)) + 1
-        noise = np.random.normal(0, 1, len(individual.phenome))
-        return np.dot(indices, np.power(individual.phenome, 4)) + np.sum(noise)
+        indices = np.arange(len(phenome)) + 1
+        noise = np.random.normal(0, 1, len(phenome))
+        return np.dot(indices, np.power(phenome, 4)) + np.sum(noise)
 
     def worse_than(self, first_fitness, second_fitness):
         """
@@ -432,18 +432,18 @@ class ShekelProblem(ScalarProblem):
         self.k = k
         self.c = c
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued list phenome (the output varies, since the function has noise).
 
         :param phenome: real-valued to be evaluated
         :returns: its fitness
         """
-        assert (len(individual.phenome) == 2)
+        assert (len(phenome) == 2)
 
         def f(j):
-            return self.c[j] + (individual.phenome[0] - self.points[0][j]
-                                ) ** 6 + (individual.phenome[1] - self.points[1][j]) ** 6
+            return self.c[j] + (phenome[0] - self.points[0][j]
+                                ) ** 6 + (phenome[1] - self.points[1][j]) ** 6
 
         return 1 / (1 / self.k + np.sum([1 / f(j) for j in range(25)]))
 
@@ -506,19 +506,19 @@ class GriewankProblem(ScalarProblem):
     def __init__(self, maximize=False):
         super().__init__(maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
-        t1 = np.sum(np.power(individual.phenome, 2) / 4000)
-        i_vector = np.sqrt(np.arange(1, len(individual.phenome) + 1))
-        t2 = np.prod(np.cos(individual.phenome / i_vector))
+                              f"Got {type(phenome)}."))
+        t1 = np.sum(np.power(phenome, 2) / 4000)
+        i_vector = np.sqrt(np.arange(1, len(phenome) + 1))
+        t2 = np.prod(np.cos(phenome / i_vector))
         return t1 - t2 + 1
 
     def __str__(self):
@@ -564,20 +564,20 @@ class AckleyProblem(ScalarProblem):
         self.b = b
         self.c = c
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
-        d = len(individual.phenome)
+                              f"Got {type(phenome)}."))
+        d = len(phenome)
         t1 = -self.a * np.exp(-self.b * np.sqrt(1.0 /
-                                                d * np.sum(np.power(individual.phenome, 2))))
-        t2 = np.exp(1.0 / d * np.sum(np.cos(self.c * individual.phenome)))
+                                                d * np.sum(np.power(phenome, 2))))
+        t2 = np.exp(1.0 / d * np.sum(np.cos(self.c * phenome)))
         return t1 - t2 + self.a + np.e
 
     def __str__(self):
@@ -625,18 +625,18 @@ class WeierstrassProblem(ScalarProblem):
         self.a = a
         self.b = b
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
+                              f"Got {type(phenome)}."))
         result = 0
-        for x in individual.phenome:
+        for x in phenome:
             t1 = 0
             for k in range(self.kmax):
                 t1 += self.a ** k * \
@@ -647,7 +647,7 @@ class WeierstrassProblem(ScalarProblem):
         for k in range(self.kmax):
             t2 += self.a ** k * np.cos(np.pi * (self.b ** k))
 
-        result = result - len(individual.phenome) * t2
+        result = result - len(phenome) * t2
         return result
 
     def __str__(self):
@@ -723,25 +723,25 @@ class LangermannProblem(ScalarProblem):
             raise ValueError(
                 f"Got a value of shape {self.a.shape} for 'a', but must be a {m}xd matrix.")
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        assert (individual.phenome is not None)
-        if not isinstance(individual.phenome, np.ndarray):
+        assert (phenome is not None)
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
-        if len(individual.phenome) != self.a.shape[1]:
+                              f"Got {type(phenome)}."))
+        if len(phenome) != self.a.shape[1]:
             raise ValueError(
-                f"Received an {len(individual.phenome)}-dimensional phenome, but this is a {self.a.shape[1]}-dimensional Langerman function.")
+                f"Received an {len(phenome)}-dimensional phenome, but this is a {self.a.shape[1]}-dimensional Langerman function.")
         result = 0
         for i in range(self.m):
             result -= self.c[i] * np.exp(
-                -1.0 / np.pi * np.sum((individual.phenome - self.a[i]) ** 2)) \
-                      * np.cos(np.pi * np.sum((individual.phenome - self.a[i]) ** 2))
+                -1.0 / np.pi * np.sum((phenome - self.a[i]) ** 2)) \
+                      * np.cos(np.pi * np.sum((phenome - self.a[i]) ** 2))
         return result
 
     def __str__(self):
@@ -820,24 +820,24 @@ class LunacekProblem(ScalarProblem):
         self.mu_2 = mu_2 if mu_2 is not None else - \
             np.sqrt((mu_1**2 - d) / self.s)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
         :param phenome: real-valued vector to be evaluated
         :returns: its fitness.
         """
-        assert(individual.phenome is not None)
-        if len(individual.phenome) != self.N:
+        assert(phenome is not None)
+        if len(phenome) != self.N:
             warnings.warn(
-                f"Phenome has length {len(individual.phenome)}, but this function expected {self.N}-dimensional input.")
-        if not isinstance(individual.phenome, np.ndarray):
+                f"Phenome has length {len(phenome)}, but this function expected {self.N}-dimensional input.")
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
-        sphere1 = np.sum((individual.phenome - self.mu_1)**2)
-        sphere2 = self.d * len(individual.phenome) + self.s * \
-            np.sum((individual.phenome - self.mu_2)**2)
-        sinusoid = 10 * np.sum(1 - np.cos(2 * np.pi * (individual.phenome - self.mu_1)))
+                              f"Got {type(phenome)}."))
+        sphere1 = np.sum((phenome - self.mu_1)**2)
+        sphere2 = self.d * len(phenome) + self.s * \
+            np.sum((phenome - self.mu_2)**2)
+        sinusoid = 10 * np.sum(1 - np.cos(2 * np.pi * (phenome - self.mu_1)))
         return min(sphere1, sphere2) + sinusoid
 
     def __str__(self):
@@ -884,20 +884,20 @@ class SchwefelProblem(ScalarProblem):
         super().__init__(maximize)
         self.alpha = alpha
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
-        :param individual: individual with a real-valued phenome to be evaluated
+        :param phenome: phenome with a real-valued phenome to be evaluated
         :returns: its fitness.
         """
-        assert(individual.phenome is not None)
-        if not isinstance(individual.phenome, np.ndarray):
+        assert(phenome is not None)
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
+                              f"Got {type(phenome)}."))
 
-        return np.sum(-individual.phenome * np.sin(np.sqrt(np.abs(individual.phenome)))
-                      ) + self.alpha * len(individual.phenome)
+        return np.sum(-phenome * np.sin(np.sqrt(np.abs(phenome)))
+                      ) + self.alpha * len(phenome)
 
     def __str__(self):
         """Returns the name of the class.
@@ -937,14 +937,14 @@ class GaussianProblem(ScalarProblem):
         self.width = 1
         self.height = 1
 
-    def evaluate(self, individual):
-        assert(individual.phenome is not None)
+    def evaluate(self, phenome):
+        assert(phenome is not None)
 
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
+                              f"Got {type(phenome)}."))
 
-        return self.height * np.exp(-np.sum(np.power(individual.phenome/self.width, 2)))
+        return self.height * np.exp(-np.sum(np.power(phenome/self.width, 2)))
 
     def __str__(self):
         """Returns the name of the class.
@@ -1014,20 +1014,20 @@ class CosineFamilyProblem(ScalarProblem):
         self.global_optima_counts = np.array(global_optima_counts)
         self.local_optima_counts = np.array(local_optima_counts)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Computes the function value from a real-valued phenome.
 
-        :param phenome: individual with a real-valued phenome vector to be evaluated
+        :param phenome: phenome with a real-valued phenome vector to be evaluated
         :returns: its fitness.
         """
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
-        term1 = -np.cos((self.global_optima_counts - 1) * 2 * np.pi * individual.phenome)
+                              f"Got {type(phenome)}."))
+        term1 = -np.cos((self.global_optima_counts - 1) * 2 * np.pi * phenome)
         term2 = - self.alpha * \
             np.cos((self.global_optima_counts - 1) * 2 *
-                   np.pi * self.local_optima_counts * individual.phenome)
+                   np.pi * self.local_optima_counts * phenome)
         value = np.sum(term1 + term2) / (2 * self.dimensions)
         return value
 
@@ -1141,8 +1141,8 @@ class QuadraticFamilyProblem(ScalarProblem):
     def dimensions(self):
         return len(self.offset_vectors[0])
         
-    def evaluate(self, individual):
-        basin_values = [ p.evaluate(individual) for p in self.parabaloids ]
+    def evaluate(self, phenome):
+        basin_values = [ p.evaluate(phenome) for p in self.parabaloids ]
         return np.min(basin_values)
 
     @classmethod
@@ -1151,7 +1151,7 @@ class QuadraticFamilyProblem(ScalarProblem):
         Convenient method to generate a QuadraticFamilyProblem by randomly sampling the matrices that define it.
 
         >>> problem = QuadraticFamilyProblem.generate(10, 20, num_global_optima = 2)
-        >>> x = problem.evaluate(Individual(np.array([0.0, 0.5, 0.0, 0.6, 0.0, 0.7, 0.6, 0.8, 4.3, 0.2])))
+        >>> x = problem.evaluate(np.array([0.0, 0.5, 0.0, 0.6, 0.0, 0.7, 0.6, 0.8, 4.3, 0.2]))
         """
         assert(num_basins >= 0)
         assert(len(width_bounds) == 2)
@@ -1235,8 +1235,8 @@ class ParabaloidProblem(ScalarProblem):
         # Construct the matrix for the quadratic form
         self.matrix = R.T @ D @ R
 
-    def evaluate(self, individual):
-        return individual.phenome.T @ self.matrix @ individual.phenome
+    def evaluate(self, phenome):
+        return phenome.T @ self.matrix @ phenome
 
 
 ##############################
@@ -1304,7 +1304,7 @@ class TranslatedProblem(ScalarProblem):
         offset = np.random.uniform(min_offset, max_offset, dimensions)
         return cls(problem, offset, maximize=maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Evaluate the fitness of a point after translating the fitness function.
 
@@ -1314,23 +1314,20 @@ class TranslatedProblem(ScalarProblem):
         >>> offset = [-1.0, -1.0, 1.0, 1.0, -5.0]
         >>> t_sphere = TranslatedProblem(SpheroidProblem(), offset)
         >>> genome = np.array([0.5, 2.0, 3.0, 8.5, -0.6])
-        >>> t_sphere.evaluate(Individual(genome))
+        >>> t_sphere.evaluate(genome)
         90.86
         """
-        assert (len(individual.phenome) == len(self.offset)), \
-            f"Tried to evalute a {len(individual.phenome)}-D genome in a " \
+        assert (len(phenome) == len(self.offset)), \
+            f"Tried to evalute a {len(phenome)}-D genome in a " \
             f"{len(self.offset)}-D fitness function. "
         # Substract the offset so that we are moving the origin *to* the offset.
         # This way we can think of it as offsetting the fitness function,
         # rather than the input points.
-        if not isinstance(individual.phenome, np.ndarray):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
-        new_phenome = individual.phenome - self.offset
-
-        new_ind = individual.clone()
-        new_ind.phenome = new_phenome
-        return self.problem.evaluate(new_ind)
+                              f"Got {type(phenome)}."))
+        new_phenome = phenome - self.offset
+        return self.problem.evaluate(new_phenome)
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1360,19 +1357,16 @@ class ScaledProblem(ScalarProblem):
         self.old_bounds = problem.bounds
         self.bounds = new_bounds
 
-    def evaluate(self, individual):
-        if not isinstance(individual.phenome, np.ndarray):
+    def evaluate(self, phenome):
+        if not isinstance(phenome, np.ndarray):
             raise ValueError(("Expected phenome to be a numpy array. "
-                              f"Got {type(individual.phenome)}."))
+                              f"Got {type(phenome)}."))
         transformed_phenome = self.old_bounds[0] + (
-                    individual.phenome - self.bounds[0]) / (
+                    phenome - self.bounds[0]) / (
                                           self.bounds[1] - self.bounds[0]) \
                               * (self.old_bounds[1] - self.old_bounds[0])
-        assert (len(transformed_phenome) == len(individual.phenome))
-
-        transformed_ind = individual.clone()
-        transformed_ind.phenome = transformed_phenome
-        return self.problem.evaluate(transformed_ind)
+        assert (len(transformed_phenome) == len(phenome))
+        return self.problem.evaluate(transformed_phenome)
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1529,7 +1523,7 @@ class MatrixTransformedProblem(ScalarProblem):
         matrix = random_orthonormal_matrix(dimensions)
         return cls(problem, matrix, maximize)
 
-    def evaluate(self, individual):
+    def evaluate(self, phenome):
         """
         Evaluated the fitness of a point on the transformed fitness landscape.
 
@@ -1538,7 +1532,7 @@ class MatrixTransformedProblem(ScalarProblem):
 
         >>> import numpy as np
         >>> s = TranslatedProblem(SpheroidProblem(), offset=[0, 1])
-        >>> round(s.evaluate(Individual(np.array([0, 1]))), 5)
+        >>> round(s.evaluate(np.array([0, 1])), 5)
         0
 
         Now let's take a rotation matrix that transforms the space by pi/2
@@ -1552,22 +1546,20 @@ class MatrixTransformedProblem(ScalarProblem):
 
         The rotation has moved the new global optimum to (1, 0)
 
-        >>> round(r.evaluate(Individual(np.array([1, 0]))), 5)
+        >>> round(r.evaluate(np.array([1, 0])), 5)
         0.0
 
         The point (0, 1) lies at a distance of sqrt(2) from the new optimum,
         and has a fitness of 2:
 
-        >>> round(r.evaluate(Individual(np.array([0, 1]))), 5)
+        >>> round(r.evaluate(np.array([0, 1])), 5)
         2.0
         """
-        assert (len(individual.phenome) == len(
-            self.matrix)), f"Tried to evalute a {len(individual.phenome)}-D genome in a " \
+        assert (len(phenome) == len(
+            self.matrix)), f"Tried to evalute a {len(phenome)}-D genome in a " \
                            f"{len(self.matrix)}-D fitness function. "
-        new_point = np.matmul(self.matrix, individual.phenome)
-        new_ind = individual.clone()
-        new_ind.phenome = new_point
-        return self.problem.evaluate(new_ind)
+        new_point = np.matmul(self.matrix, phenome)
+        return self.problem.evaluate(new_point)
 
     def __str__(self):
         """Returns the name of this class, followed by the `__str__ of the wrapped class
@@ -1641,7 +1633,7 @@ def plot_2d_problem(problem, xlim=None, ylim=None, kind='surface',
     """
 
     def call(phenome):
-        return problem.evaluate(Individual(phenome))
+        return problem.evaluate(phenome)
 
     if xlim is None:
         xlim = problem.bounds

--- a/tests/real_rep/test_problems.py
+++ b/tests/real_rep/test_problems.py
@@ -17,7 +17,7 @@ def test_GriewankProblem_eval():
     expected = t[0]**2/4000 + t[1]**2/4000 - np.cos(t[0]/np.sqrt(1))*np.cos(t[1]/np.sqrt(2)) + 1
 
     p = problems.GriewankProblem()
-    assert(approx(expected) == p.evaluate(Individual(t)))
+    assert(approx(expected) == p.evaluate(t))
 
 
 
@@ -30,5 +30,5 @@ def test_WeierstrassProblem_eval():
     """
     p = problems.WeierstrassProblem()
 
-    assert(approx(0) == p.evaluate(Individual(np.array([0, 0]))))
-    assert(approx(0) == p.evaluate(Individual(np.array([0]*25))))
+    assert(approx(0) == p.evaluate(np.array([0, 0])))
+    assert(approx(0) == p.evaluate(np.array([0]*25)))

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -24,7 +24,7 @@ def test_averagefitnessproblem():
                     wrapped_problem = real_prob.NoisyQuarticProblem(),
                     n = n)
     x = [ 1, 1, 1, 1 ]
-    y = p.evaluate(Individual(x))
+    y = p.evaluate(x)
 
     # The value of the noisy-quartic is sum(i*x**4) plus additive Gaussian noise
     expected_mean = 10.0  # = 1 + 2 + 3 + 4 


### PR DESCRIPTION
@markcoletti,

I have rolled back the `Problem.evaluate(individual)` change to be `Problem.evaluate(phenome)` again.  And in select places, `evaluate()` now accepts `kwargs`---namely an `individual` argument so that the full individual can be passed in when needed.

I created a new `Individual` subclass, `WholeEvaluatedIndividual`, with an `evaluate_impl()` method that calls `problem.evaluate(phenome, individual=self)`.

One tricky bit I'd like your feedback on: there is a `grouped_evaluate()` operator that I created for applications where many individuals are evaluated simultaneously (ex. externally in a GPU-based simulator).  It uses a special `evaluate_multiple()` function that all `Problem` instances have. I have hard-coded `grouped_evaluate()` to always pass in an `individuals` argument to `problem.multiple_evaluate`:

![image](https://user-images.githubusercontent.com/313154/185919957-71302f96-80aa-4646-a690-8ca9d37ab88e.png)

When using this with `dask`, I'm not sure if this violates the encapsulation that we want.  Will the mere act of passing extra data to `Problem` trigger memory bloat in `dask`, even if the `Problem` implementation ignores the passed data? If so, we can add a flag to `grouped_evaluate()` so the extra data is only passed in to `Problem` when we want it.  But if not, it's cleaner to have no flag and just pass an ignored argument.

This PR resolves #193.