### PR TITLE
random_search() now returns a list instead of an iterator.

### DIFF
--- a/examples/advanced/cgp.py
+++ b/examples/advanced/cgp.py
@@ -123,18 +123,16 @@ def cgp_cmd(gens):
 @click.option('--evals', default=5000)
 def random(evals):
     """Use random search over a CGP representation to solve the XOR function."""
-    ea = random_search(evals,
-            representation=cgp_representation,
+    best_found = random_search(evals,
+                representation=cgp_representation,
 
-            # Our fitness function will be to solve the XOR problem
-            problem=xor_problem,
+                # Our fitness function will be to solve the XOR problem
+                problem=xor_problem,
 
-            pipeline=[
-                probe.FitnessStatsCSVProbe(stream=sys.stdout)
-            ] + cgp_visual_probes(modulo=10)
-    )
-
-    list(ea)
+                pipeline=[
+                    probe.FitnessStatsCSVProbe(stream=sys.stdout)
+                ] + cgp_visual_probes(modulo=10)
+        )
 
 
 ##############################

--- a/leap_ec/algorithm.py
+++ b/leap_ec/algorithm.py
@@ -324,7 +324,7 @@ def random_search(evaluations, problem, representation, pipeline=(),
     >>> from leap_ec.decoder import IdentityDecoder
     >>> from leap_ec.representation import Representation
     >>> from leap_ec.individual import Individual
-    >>> ea = random_search(evaluations=100,
+    >>> result = random_search(evaluations=100,
     ...                    problem=MaxOnes(),      # Solve a MaxOnes Boolean optimization problem
     ...
     ...                    representation=Representation(
@@ -332,20 +332,11 @@ def random_search(evaluations, problem, representation, pipeline=(),
     ...                        decoder=IdentityDecoder(),     # Genotype and phenotype are the same for this task
     ...                        initialize=create_binary_sequence(length=10)  # Initial genomes are random binary sequences
     ...                    ))
-    >>> ea # doctest:+ELLIPSIS
-    <generator ...>
 
-    The algorithm evaluates lazily when you query the generator:
+    The algorithm outputs a list containing just the best-found individual:
 
-    >>> print(*list(ea), sep='\\n') # doctest:+ELLIPSIS
-    (1, Individual(...))
-    (2, Individual(...))
-    ...
-    (100, Individual(...))
-
-    The best individual reported from the initial population  is reported at
-    generation 0) followed by the best-so-far individual at each subsequent
-    generation.
+    >>> result # doctest:+ELLIPSIS
+    [Individual(...)]
     """
     # Set up an evaluation counter that records the current generation to
     # context
@@ -368,8 +359,8 @@ def random_search(evaluations, problem, representation, pipeline=(),
 
         evaluation_counter()  # Increment to the next evaluation
 
-        # Output the best-so-far individual for each generation
-        yield (evaluation_counter.generation(), bsf)
+    # Output a list containing just the best-found solution
+    return [ bsf ]
 
 
 ##############################


### PR DESCRIPTION
Increment on #225
 - `random_search()` now follows the convention of returning a list instead of an interator