### PR TITLE
240 birth counter not properly handled in asea code

### DIFF
--- a/leap_ec/distrib/asynchronous.py
+++ b/leap_ec/distrib/asynchronous.py
@@ -200,7 +200,10 @@ def steady_state(client, births, init_pop_size, pop_size,
                 # if we want the non-viables to not count towards the budget
                 # then we need to decrement the birth counter to ensure that
                 # a new individual is spawned to replace it.
+                logger.debug(f'Non-viable individual, decrementing birth'
+                             f'count.  Was {birth_counter.births()}')
                 birth_counter.do_decrement()
+                logger.debug(f'Birth count now {birth_counter.births()}')
 
         inserter(evaluated, pop, pop_size)
 

--- a/leap_ec/distrib/asynchronous.py
+++ b/leap_ec/distrib/asynchronous.py
@@ -194,12 +194,16 @@ def steady_state(client, births, init_pop_size, pop_size,
         logger.debug('%d evaluated: %s %s', i, str(evaluated.genome),
                      str(evaluated.fitness))
 
-        if not count_nonviable and not is_viable(evaluated):
-            # If we don't want non-viable individuals to count towards the
-            # birth budget, then we need to decrement the birth count that was
-            # incremented when it was created for this individual since it
-            # was broken in some way.
+        if is_viable(evaluated):
             birth_counter()
+        elif count_nonviable:
+            # Even if the individual is not-viable, we want to count it towards
+            # the birth budget
+            birth_counter()
+        else:
+            # The individual is not viable and we don't want to count it towards
+            # the birth budget.
+            pass
 
         inserter(evaluated, pop, pop_size)
 

--- a/leap_ec/distrib/asynchronous.py
+++ b/leap_ec/distrib/asynchronous.py
@@ -178,7 +178,7 @@ def steady_state(client, births, init_pop_size, pop_size,
     pop = []
 
     # Bookkeeping for tracking the number of births
-    birth_counter = util.inc_births(context, start=len(initial_population))
+    birth_counter = util.inc_births(context)
 
     for i, evaluated_future in enumerate(as_completed_iter):
 
@@ -195,11 +195,11 @@ def steady_state(client, births, init_pop_size, pop_size,
                      str(evaluated.fitness))
 
         if is_viable(evaluated):
-            birth_counter()
+            birth_counter.do_increment()
         elif count_nonviable:
             # Even if the individual is not-viable, we want to count it towards
             # the birth budget
-            birth_counter()
+            birth_counter.do_increment()
         else:
             # The individual is not viable and we don't want to count it towards
             # the birth budget.
@@ -222,7 +222,5 @@ def steady_state(client, births, init_pop_size, pop_size,
                 future = client.submit(evaluate(context=context), child,
                                        pure=False)
                 as_completed_iter.add(future)
-
-            birth_counter(len(offspring))
 
     return pop

--- a/leap_ec/util.py
+++ b/leap_ec/util.py
@@ -214,6 +214,7 @@ def inc_births(context=context, start=0, callbacks=()):
         return curr_births
 
     do_increment.births = births
+    do_increment.do_increment = do_increment
     do_increment.do_decrement = do_decrement
 
     return do_increment

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -122,6 +122,7 @@ def test_meet_budget_count_nonviable():
                            representation=representation,
                            problem=BrokenProblem(3, counter),
                            evaluated_probe=my_accumulate,
+                           count_nonviable=False,
                            offspring_pipeline=[
                                ops.random_selection,
                                ops.clone,

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -27,15 +27,9 @@ def accumulate():
     def individuals():
         return inds
 
-    def _accumulate(next_individual: Iterator):
+    def _accumulate(individual):
         nonlocal inds
-
-        while True:
-            individual = next(next_individual)
-
-            inds.append(individual)
-
-            yield individual
+        inds.append(individual)
 
     # convenient accessor for individuals
     _accumulate.individuals = individuals
@@ -48,7 +42,8 @@ representation = Representation(create_binary_sequence(3))
 def test_meet_budget():
     """ This test is to ensure that we meet our birth budget exactly """
     with Client() as client:
-
+        # We accumulate all the evaluated individuals the number of
+        # which should be equal to our birth budget of four.
         my_accumulate = accumulate()
 
         pop = steady_state(client=client,
@@ -57,16 +52,16 @@ def test_meet_budget():
                            pop_size=2,
                            representation=representation,
                            problem=MaxOnes(),
+                           evaluated_probe=my_accumulate,
                            offspring_pipeline=[
                                ops.random_selection,
                                ops.clone,
-                               my_accumulate,
                                ops.pool(size=1)]
                            )
 
     inds = my_accumulate.individuals()
 
-    assert len(pop) == 2
+    assert len(inds) == 4
 
 
 def test_meet_budget_count_nonviable():

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -2,7 +2,8 @@
     Tests for leap_ec.distrib.async for handling birth budgets
 """
 import numpy as np
-from distributed import Client
+from distributed import Client, Variable
+from math import nan
 
 import leap_ec.ops as ops
 from typing import Iterator
@@ -15,6 +16,7 @@ from leap_ec.individual import Individual
 from leap_ec.binary_rep.initializers import create_binary_sequence
 from leap_ec.binary_rep.ops import mutate_bitflip
 from leap_ec.representation import Representation
+from leap_ec.problem import ScalarProblem
 
 def accumulate():
     """ This pipeline operator accumulates individuals as they move
@@ -37,7 +39,8 @@ def accumulate():
     return _accumulate
 
 
-representation = Representation(create_binary_sequence(3))
+representation = Representation(create_binary_sequence(3),
+                                individual_cls=DistributedIndividual)
 
 def test_meet_budget():
     """ This test is to ensure that we meet our birth budget exactly """
@@ -56,6 +59,7 @@ def test_meet_budget():
                            offspring_pipeline=[
                                ops.random_selection,
                                ops.clone,
+                               ops.evaluate,
                                ops.pool(size=1)]
                            )
 
@@ -64,9 +68,72 @@ def test_meet_budget():
     assert len(inds) == 4
 
 
+class Counter:
+    """ From https://distributed.dask.org/en/stable/actors.html
+
+        Used to manage birth counts in a concurrent safe setting.
+     """
+    n = 0
+
+    def __init__(self):
+        self.n = 0
+
+    def increment(self):
+        self.n += 1
+        return self.n
+
+    def add(self, x):
+        self.n += x
+        return self.n
+
+
+class BrokenProblem(ScalarProblem):
+    """ Intentionally throw an exception at an interval
+
+        The intent is to deterministically create non-viable
+        individuals caused by throwing an exception during
+        evaluations at a predetermined interval.
+    """
+    def __init__(self, n, counter):
+        """ :param n: throw an exception at the `n`th eval """
+        super().__init__(True)
+        self.n = n
+        self.counter = counter
+    def evaluate(self, phenome, *args, **kwargs):
+        self.counter.increment()
+        if self.counter.n == self.n:
+            raise RuntimeError('Dummy Exception')
+        return self.counter.n
+
+
 def test_meet_budget_count_nonviable():
     """ Birth budget counting non-viable individuals """
-    pass
+    with Client() as client:
+        # Create a Counter on a worker
+        future = client.submit(Counter, actor=True)
+        counter = future.result()  # Get back a pointer to that object
+
+        # We accumulate all the evaluated individuals the number of
+        # which should be equal to our birth budget of four.
+        my_accumulate = accumulate()
+
+        pop = steady_state(client=client,
+                           births=4,
+                           init_pop_size=2,
+                           pop_size=2,
+                           representation=representation,
+                           problem=BrokenProblem(3, counter),
+                           evaluated_probe=my_accumulate,
+                           offspring_pipeline=[
+                               ops.random_selection,
+                               ops.clone,
+                               ops.evaluate,
+                               ops.pool(size=1)]
+                           )
+
+    inds = my_accumulate.individuals()
+
+    assert len(inds) == 5
 
 def test_meet_budget_do_not_count_nonviable():
     """ Birth budget without counting non-viable individuals """

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -1,0 +1,78 @@
+"""
+    Tests for leap_ec.distrib.async for handling birth budgets
+"""
+import numpy as np
+from distributed import Client
+
+import leap_ec.ops as ops
+from typing import Iterator
+from leap_ec.binary_rep.problems import MaxOnes
+from leap_ec.distrib.evaluate import evaluate, is_viable
+from leap_ec.distrib.individual import DistributedIndividual
+from leap_ec.distrib.asynchronous import steady_state
+from leap_ec.global_vars import context
+from leap_ec.individual import Individual
+from leap_ec.binary_rep.initializers import create_binary_sequence
+from leap_ec.binary_rep.ops import mutate_bitflip
+from leap_ec.representation import Representation
+
+def accumulate():
+    """ This pipeline operator accumulates individuals as they move
+        through the pipeline.
+
+        TODO consider moving this to probe.py
+    """
+    inds = []
+
+    def individuals():
+        return inds
+
+    def _accumulate(next_individual: Iterator):
+        nonlocal inds
+
+        while True:
+            individual = next(next_individual)
+
+            inds.append(individual)
+
+            yield individual
+
+    # convenient accessor for individuals
+    _accumulate.individuals = individuals
+
+    return _accumulate
+
+
+representation = Representation(create_binary_sequence(3))
+
+def test_meet_budget():
+    """ This test is to ensure that we meet our birth budget exactly """
+    with Client() as client:
+
+        my_accumulate = accumulate()
+
+        pop = steady_state(client=client,
+                           births=4,
+                           init_pop_size=2,
+                           pop_size=2,
+                           representation=representation,
+                           problem=MaxOnes(),
+                           offspring_pipeline=[
+                               ops.random_selection,
+                               ops.clone,
+                               my_accumulate,
+                               ops.pool(size=1)]
+                           )
+
+    inds = my_accumulate.individuals()
+
+    assert len(pop) == 2
+
+
+def test_meet_budget_count_nonviable():
+    """ Birth budget counting non-viable individuals """
+    pass
+
+def test_meet_budget_do_not_count_nonviable():
+    """ Birth budget without counting non-viable individuals """
+    pass

--- a/tests/distributed/test_evaluate.py
+++ b/tests/distributed/test_evaluate.py
@@ -1,14 +1,14 @@
 """
     Tests for leap_ec.distrib.evaluate.
 """
+import numpy as np
 from distributed import Client
 
-import numpy as np
-
-from leap_ec.individual import Individual
 from leap_ec.binary_rep.problems import MaxOnes
-from leap_ec.distrib.evaluate import evaluate
+from leap_ec.distrib.evaluate import evaluate, is_viable
+from leap_ec.distrib.individual import DistributedIndividual
 from leap_ec.global_vars import context
+from leap_ec.individual import Individual
 
 
 def test_good_eval():
@@ -39,11 +39,15 @@ def test_broken_individual_eval():
         TODO implement this
     """
     # set up a basic dask local cluster
+    with Client() as client:
+        # hand craft an individual that will intentionally fail by not
+        # assigning it a Problem class
+        individual = DistributedIndividual(np.array([1, 1]),
+                                           problem=None)
 
-    # hand craft an individual that should throw an exception on evaluation
+        future = client.submit(evaluate(context=context),
+                               individual)
 
-    # evaluate that individual
+        evaluated_individual = future.result()
 
-    # check that the individual state is sane given it is non-viable
-
-    pass
+        assert not is_viable(evaluated_individual)


### PR DESCRIPTION
This corrects a problem with handling birth budgets wrt non-viable individuals (i.e., individuals for which an exception was thrown during evaluation) where counts toward budget totals were not properly updated.  Moreover, this adds unit tests to exercise various birth budget scenarios.