### PR TITLE
Fix various warnings and small bugs

### DIFF
--- a/leap_ec/executable_rep/neural_network.py
+++ b/leap_ec/executable_rep/neural_network.py
@@ -16,7 +16,10 @@ def sigmoid(x):
     """A logistic sigmoid activation function.  Accepts array-like inputs,
     and uses NumPy for efficient computation.
     """
-    return 1/(1+np.exp(-x))
+    # Error handling, prevents overflow with negative or positive exponents
+    # For x > 0, equivalent to 1 / (1 + e^-x)
+    # For x < 0, equivalent to e^x / (1 + e^x)
+    return np.exp(np.minimum(0, x)) / (1 + np.exp(-np.abs(x)))
 
 
 ##############################
@@ -34,7 +37,9 @@ def relu(x):
 def softmax(x):
     """A softmax activation function.  Accepts array-like input and normalizes
     each element relative to the others."""
-    return np.exp(x)/np.sum(np.exp(x))
+    # Softmax is invariant against translation, this make sure all exponents are <= 0
+    safe_exp = np.exp(x - np.max(x))
+    return safe_exp / np.sum(safe_exp)
 
 
 ##############################

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -110,30 +110,29 @@ class BrokenProblem(ScalarProblem):
 
 def test_meet_budget_count_nonviable():
     """ Birth budget counting non-viable individuals """
-    with Client(LocalCluster(processes=False,
-                             threads_per_worker=1,
-                             n_workers=1)) as client:
-        # Create a Counter on a worker
-        future = client.submit(Counter, actor=True)
-        counter = future.result()  # Get back a pointer to that object
+    with LocalCluster(processes=False, threads_per_worker=1, n_workers=1) as cluster:
+        with Client(cluster) as client:
+            # Create a Counter on a worker
+            future = client.submit(Counter, actor=True)
+            counter = future.result()  # Get back a pointer to that object
 
-        # We accumulate all the evaluated individuals the number of
-        # which should be equal to our birth budget of four.
-        my_accumulate = accumulate()
+            # We accumulate all the evaluated individuals the number of
+            # which should be equal to our birth budget of four.
+            my_accumulate = accumulate()
 
-        pop = steady_state(client=client,
-                           max_births=4,
-                           init_pop_size=2,
-                           pop_size=2,
-                           representation=representation,
-                           problem=BrokenProblem(1, counter),
-                           evaluated_probe=my_accumulate,
-                           count_nonviable=False,
-                           offspring_pipeline=[
-                               ops.random_selection,
-                               ops.clone,
-                               ops.pool(size=1)]
-                           )
+            pop = steady_state(client=client,
+                            max_births=4,
+                            init_pop_size=2,
+                            pop_size=2,
+                            representation=representation,
+                            problem=BrokenProblem(1, counter),
+                            evaluated_probe=my_accumulate,
+                            count_nonviable=False,
+                            offspring_pipeline=[
+                                ops.random_selection,
+                                ops.clone,
+                                ops.pool(size=1)]
+                            )
 
     inds = my_accumulate.individuals()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ Run all of our example algorithms and ensure they have no exceptions.
 """
 import pathlib
 import runpy
+import subprocess
 import os
 import sys
 
@@ -20,15 +21,6 @@ scripts = pathlib.Path(__file__, '..', '..', 'examples').resolve().rglob('*.py')
 @pytest.mark.parametrize('script', scripts)
 def test_script_execution(script):
     print(f"Running {script}")
-    # We have to tweak sys.argv to avoid the pytest arguments from being passed along to our scripts
-    sys_orig = sys.argv
-    sys.argv = [ str(script) ]
     os.environ[test_env_var] = 'True'
-
-    try:
-        runpy.run_path(str(script), run_name='__main__')
-    except SystemExit as e:
-        # Some scripts may explicitly call `sys.exit()`, in which case we'll check the error code
-        assert(e.code == 0)
-    
-    sys.argv = sys_orig
+    proc = subprocess.run([sys.executable, str(script)], stdout=sys.stdout, stderr=sys.stderr)
+    assert proc.returncode == 0, f"Script {script} returned non-zero exit status {proc.returncode}"


### PR DESCRIPTION
Mainly fixes #247 

`dask` was giving warnings when running test_examples, which turned out to have been caused by using `runpy` for those tests. Swapping over to `subprocess` keeps `dask` better isolated from `pytest` and/or avoids issues with how `runpy` works internally.

Also fixed a small issue in the `distributed` tests that was leaving a cluster open when the test closed. Just required putting the cluster in a `with` statement.

Lastly, once the warnings were cleaned up I noticed a recurring warning in the activation functions of `neural_network` where sigmoid was tending to infinity in the divisor. While `numpy` gracefully and properly handles that, its probably better to just not have those kinds of math issues floating around. I modified that, and softmax as a plus, to force negative exponents (which can be handled much more cleanly).