### PR TITLE
Change probes to be generic for generations or births

### DIFF
--- a/leap_ec/executable_rep/neural_network.py
+++ b/leap_ec/executable_rep/neural_network.py
@@ -16,7 +16,10 @@ def sigmoid(x):
     """A logistic sigmoid activation function.  Accepts array-like inputs,
     and uses NumPy for efficient computation.
     """
-    return 1/(1+np.exp(-x))
+    # Error handling, prevents overflow with negative or positive exponents
+    # For x > 0, equivalent to 1 / (1 + e^-x)
+    # For x < 0, equivalent to e^x / (1 + e^x)
+    return np.exp(np.minimum(0, x)) / (1 + np.exp(-np.abs(x)))
 
 
 ##############################
@@ -34,7 +37,9 @@ def relu(x):
 def softmax(x):
     """A softmax activation function.  Accepts array-like input and normalizes
     each element relative to the others."""
-    return np.exp(x)/np.sum(np.exp(x))
+    # Softmax is invariant against translation, this make sure all exponents are <= 0
+    safe_exp = np.exp(x - np.max(x))
+    return safe_exp / np.sum(safe_exp)
 
 
 ##############################

--- a/leap_ec/multiobjective/probe.py
+++ b/leap_ec/multiobjective/probe.py
@@ -4,7 +4,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
-
+from leap_ec.util import get_step
 from leap_ec.probe import PopulationMetricsPlotProbe
 from leap_ec.global_vars import context
 
@@ -45,9 +45,7 @@ class ParetoPlotProbe2D(PopulationMetricsPlotProbe):
 
     def __call__(self, population):
         assert (population is not None)
-        assert ('leap' in self.context)
-        assert ('generation' in self.context['leap'])
-        step = self.context['leap']['generation']
+        step = get_step(self.context)
 
         if step % self.modulo == 0:
             self.x = np.array([ind.fitness[0] for ind in population])

--- a/leap_ec/util.py
+++ b/leap_ec/util.py
@@ -127,7 +127,8 @@ def inc_generation(start_generation: int=0, context=context, callbacks=()):
 
         # Now echo the new generation to all the registered callbacks.
         # TODO There is probably a more pythonic way to do this
-        [f(curr_generation) for f in callbacks]
+        for f in callbacks:
+            f(curr_generation)
 
         return curr_generation
 
@@ -143,10 +144,10 @@ def inc_births(context=context, start=0, callbacks=()):
     """ This tracks the current number of births
 
     The `context` is used to report the current births, though that
-    can also be given by inc_births.generation().
+    can also be obtained by inc_births.births()
 
     This will optionally call all the given callback functions whenever the
-    generation is incremented. The registered callback functions should have
+    births are incremented. The registered callback functions should have
     a signature f(int), where the int is the new birth.
 
     >>> from leap_ec.global_vars import context
@@ -199,7 +200,8 @@ def inc_births(context=context, start=0, callbacks=()):
 
         # Now echo the new generation to all the registered callbacks.
         # TODO There is probably a more pythonic way to do this
-        [f(curr_births) for f in callbacks]
+        for f in callbacks:
+            f(curr_births)
 
         return curr_births
 
@@ -222,6 +224,38 @@ def inc_births(context=context, start=0, callbacks=()):
 
     return do_increment
 
+###############################
+# Function get_step
+###############################
+def get_step(context=context, use_generation=None, use_births=None):
+    """
+    Returns the current step of an algorithm using context. Will infer which to use
+    from the context if neither is specified with `use_generation` or `use_births`.
+    If both are set to True, will raise an error.
+
+    :param context: the context from which the generations or births is taken from.
+    :param use_generation: an override to use generation.
+    :param use_births: an override to use births.
+    """
+    assert 'leap' in context, "'leap' key must be present in context"
+    
+    if use_generation is None and use_births is None:
+        assert 'generation' in context['leap'] or 'births' in context['leap'],\
+            "One of 'generation' or 'births' must be in context['leap']"
+        use_generation = 'generation' in context['leap']
+        use_births = 'births' in context['leap']
+    
+    else:
+        if use_generation:
+            assert 'generation' in context['leap'], "To use 'generation', it must be present in context['leap']"
+        if use_births:
+            assert 'generation' in context['leap'], "To use 'births', it must be present in context['leap']"
+    
+    assert use_generation != use_births, "Only one of 'generation' or 'births' can be used"
+    if use_generation:
+        return context['leap']['generation']
+    if use_births:
+        return context['leap']['births']
 
 ###############################
 # Function print_list

--- a/leap_ec/util.py
+++ b/leap_ec/util.py
@@ -246,12 +246,12 @@ def get_step(context=context, use_generation=None, use_births=None):
         use_births = 'births' in context['leap']
     
     else:
-        if use_generation:
+        if use_generation is not None and use_generation:
             assert 'generation' in context['leap'], "To use 'generation', it must be present in context['leap']"
-        if use_births:
-            assert 'generation' in context['leap'], "To use 'births', it must be present in context['leap']"
+        if use_births is not None and use_births:
+            assert 'births' in context['leap'], "To use 'births', it must be present in context['leap']"
     
-    assert use_generation != use_births, "Only one of 'generation' or 'births' can be used"
+    assert use_generation != use_births, "Only one of 'generation' or 'births' can be used at a time"
     if use_generation:
         return context['leap']['generation']
     if use_births:

--- a/leap_ec/util.py
+++ b/leap_ec/util.py
@@ -229,9 +229,9 @@ def inc_births(context=context, start=0, callbacks=()):
 ###############################
 def get_step(context=context, use_generation=None, use_births=None):
     """
-    Returns the current step of an algorithm using context. Will infer which to use
-    from the context if neither is specified with `use_generation` or `use_births`.
-    If both are set to True, will raise an error.
+    Returns the current step of an algorithm using `context`. Will infer which to use
+    if neither is specified with `use_generation` or `use_births`. If both are set
+    to True, will raise an error.
 
     :param context: the context from which the generations or births is taken from.
     :param use_generation: an override to use generation.

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -110,30 +110,29 @@ class BrokenProblem(ScalarProblem):
 
 def test_meet_budget_count_nonviable():
     """ Birth budget counting non-viable individuals """
-    with Client(LocalCluster(processes=False,
-                             threads_per_worker=1,
-                             n_workers=1)) as client:
-        # Create a Counter on a worker
-        future = client.submit(Counter, actor=True)
-        counter = future.result()  # Get back a pointer to that object
+    with LocalCluster(processes=False, threads_per_worker=1, n_workers=1) as cluster:
+        with Client(cluster) as client:
+            # Create a Counter on a worker
+            future = client.submit(Counter, actor=True)
+            counter = future.result()  # Get back a pointer to that object
 
-        # We accumulate all the evaluated individuals the number of
-        # which should be equal to our birth budget of four.
-        my_accumulate = accumulate()
+            # We accumulate all the evaluated individuals the number of
+            # which should be equal to our birth budget of four.
+            my_accumulate = accumulate()
 
-        pop = steady_state(client=client,
-                           max_births=4,
-                           init_pop_size=2,
-                           pop_size=2,
-                           representation=representation,
-                           problem=BrokenProblem(1, counter),
-                           evaluated_probe=my_accumulate,
-                           count_nonviable=False,
-                           offspring_pipeline=[
-                               ops.random_selection,
-                               ops.clone,
-                               ops.pool(size=1)]
-                           )
+            pop = steady_state(client=client,
+                            max_births=4,
+                            init_pop_size=2,
+                            pop_size=2,
+                            representation=representation,
+                            problem=BrokenProblem(1, counter),
+                            evaluated_probe=my_accumulate,
+                            count_nonviable=False,
+                            offspring_pipeline=[
+                                ops.random_selection,
+                                ops.clone,
+                                ops.pool(size=1)]
+                            )
 
     inds = my_accumulate.individuals()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ Run all of our example algorithms and ensure they have no exceptions.
 """
 import pathlib
 import runpy
+import subprocess
 import os
 import sys
 
@@ -20,15 +21,6 @@ scripts = pathlib.Path(__file__, '..', '..', 'examples').resolve().rglob('*.py')
 @pytest.mark.parametrize('script', scripts)
 def test_script_execution(script):
     print(f"Running {script}")
-    # We have to tweak sys.argv to avoid the pytest arguments from being passed along to our scripts
-    sys_orig = sys.argv
-    sys.argv = [ str(script) ]
     os.environ[test_env_var] = 'True'
-
-    try:
-        runpy.run_path(str(script), run_name='__main__')
-    except SystemExit as e:
-        # Some scripts may explicitly call `sys.exit()`, in which case we'll check the error code
-        assert(e.code == 0)
-    
-    sys.argv = sys_orig
+    proc = subprocess.run([sys.executable, str(script)], stdout=sys.stdout, stderr=sys.stderr)
+    assert proc.returncode == 0, f"Script {script} returned non-zero exit status {proc.returncode}"

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -9,7 +9,6 @@ import pytest
 
 import leap_ec.ops as ops
 from leap_ec import data
-from leap_ec.global_vars import context
 from leap_ec.probe import *
 
 
@@ -44,6 +43,9 @@ def test_AttributesCSVProbe_1():
     """When recording the attribute 'my_value' and leaving other arguments at their default,
     running CSVProbe on a population of individuals with just the attribute 'my_value' should
     produce the correct CSV-formatted output."""
+    # Create the context
+    context = {'leap':{'generation': 10}}
+    
     # Set up a population
     pop = data.test_population
 
@@ -55,10 +57,7 @@ def test_AttributesCSVProbe_1():
 
     # Setup a probe that writes to a str in memory
     stream = io.StringIO()
-    probe = AttributesCSVProbe(['my_value'], stream)
-
-    # Set the generation in the context
-    context['leap']['generation'] = 10
+    probe = AttributesCSVProbe(['my_value'], stream, context=context)
 
     # Execute
     probe(pop)
@@ -78,12 +77,12 @@ def test_AttributesCSVProbe_2(test_pop_with_attributes):
     """When recording the attribute 'my_value' and leaving other arguments at their default,
     running CSVProbe on a population of individuals with several attributes should
     produce CSV-formatted output that only records 'my_value'."""
+    # Create the context
+    context = {'leap':{'generation': 10}}
+    
     # Setup a probe that writes to a str in memory
     stream = io.StringIO()
-    probe = AttributesCSVProbe(['foo', 'bar'], stream)
-
-    # Set the generation in the context
-    context['leap']['generation'] = 10
+    probe = AttributesCSVProbe(['foo', 'bar'], stream, context=context)
 
     # Execute
     probe(test_pop_with_attributes)
@@ -101,13 +100,13 @@ def test_AttributesCSVProbe_2(test_pop_with_attributes):
 
 def test_AttributesCSVProbe_3(test_pop_with_attributes):
     """Changing the order of the attributes list changes the order of the columns."""
+    # Create the context
+    context = {'leap':{'generation': 10}}
+    
     # Setup a probe that writes to a str in memory
     stream = io.StringIO()
     # Passing params in reverse order from the other test above
-    probe = AttributesCSVProbe(['bar', 'foo'], stream)
-
-    # Set the generation in the context
-    context['leap']['generation'] = 10
+    probe = AttributesCSVProbe(['bar', 'foo'], stream, context=context)
 
     # Execute
     probe(test_pop_with_attributes)
@@ -125,12 +124,12 @@ def test_AttributesCSVProbe_3(test_pop_with_attributes):
 
 def test_AttributesCSVProbe_4(test_pop_with_attributes):
     """Providng an attribute that contains list data should work flawlessly.."""
+    # Create the context
+    context = {'leap':{'generation': 10}}
+    
     # Setup a probe that writes to a str in memory
     stream = io.StringIO()
-    probe = AttributesCSVProbe(['bar', 'baz'], stream)
-
-    # Set the generation in the context
-    context['leap']['generation'] = 10
+    probe = AttributesCSVProbe(['bar', 'baz'], stream, context=context)
 
     # Execute
     probe(test_pop_with_attributes)
@@ -148,12 +147,12 @@ def test_AttributesCSVProbe_4(test_pop_with_attributes):
 
 def test_AttributesCSVProbe_5(test_pop_with_attributes):
     """The `job` attribute should print as a column, even if its value is 0."""
+    # Create the context
+    context = {'leap':{'generation': 10}}
+    
     # Setup a probe that writes to a str in memory
     stream = io.StringIO()
-    probe = AttributesCSVProbe(['foo', 'bar'], stream, job=0)
-
-    # Set the generation in the context
-    context['leap']['generation'] = 10
+    probe = AttributesCSVProbe(['foo', 'bar'], stream, job=0, context=context)
 
     # Execute
     probe(test_pop_with_attributes)
@@ -171,6 +170,9 @@ def test_AttributesCSVProbe_5(test_pop_with_attributes):
 
 def test_AttributesCSVProbe_6(test_pop_with_attributes):
     """When printing numpy arrays with numpy_as_list=True, there should only be as many rows as indviduals."""
+    # Create the context
+    context = {'leap':{'generation': 10}}
+    
     # Alter the test population to have multidimensional numpy arrays for some important attributes
     pop = ops.pool(ops.clone(iter(test_pop_with_attributes)), len(test_pop_with_attributes))
     for ind in pop:
@@ -179,10 +181,7 @@ def test_AttributesCSVProbe_6(test_pop_with_attributes):
     
     # Setup a probe that writes to a str in memory
     stream = io.StringIO()
-    probe = AttributesCSVProbe(do_fitness=True, do_genome=True, header=False, numpy_as_list=True, stream=stream)
-
-    # Set the generation in the context
-    context['leap']['generation'] = 10
+    probe = AttributesCSVProbe(do_fitness=True, do_genome=True, header=False, numpy_as_list=True, stream=stream, context=context)
 
     # Execute
     probe(pop)


### PR DESCRIPTION
Fixes #268 
This pr also contains the bug fixes in #266.

Creates a new function in `util.py`, `get_step`, that generically checks the context for a generation or birth counter and returns it, with heavy error checking.

Changes anywhere in the probes that `step` is used (previously always taken to be generation) to use the get_step function instead for error checking and extracting the step.

Alters the probe tests to use a local context instead of the global one. (Might be a good idea for the algo tests too?)