### PR TITLE
Fix viable individuals being double counted in steady_state

### DIFF
--- a/leap_ec/distrib/asynchronous.py
+++ b/leap_ec/distrib/asynchronous.py
@@ -195,20 +195,14 @@ def steady_state(client, max_births, init_pop_size, pop_size,
         logger.debug('%d evaluated: %s %s', i, str(evaluated.genome),
                      str(evaluated.fitness))
 
-        if not is_viable(evaluated):
-            if not count_nonviable:
-                # if we want the non-viables to not count towards the budget
-                # then we need to decrement the birth counter to ensure that
-                # a new individual is spawned to replace it.
-                logger.debug(f'Non-viable individual, decrementing birth'
-                             f'count.  Was {birth_counter.births()}')
-                births = birth_counter.do_decrement()
-                logger.debug(f'Birth count now {births}')
-        else:
-            # is viable, so bump that birth count er
-            births = birth_counter.do_increment()
-            logger.debug(f'Counting a birth.  '
-                         f'Births at: {births}')
+        if not is_viable(evaluated) and not count_nonviable:
+            # if we want the non-viables to not count towards the budget
+            # then we need to decrement the birth counter to ensure that
+            # a new individual is spawned to replace it.
+            logger.debug(f'Non-viable individual, decrementing birth'
+                            f'count.  Was {birth_counter.births()}')
+            births = birth_counter.do_decrement()
+            logger.debug(f'Birth count now {births}')
 
         inserter(evaluated, pop, pop_size)
 

--- a/tests/distributed/test_budget.py
+++ b/tests/distributed/test_budget.py
@@ -61,7 +61,7 @@ def test_meet_budget():
 
     inds = my_accumulate.individuals()
 
-    assert len(inds) == 4
+    assert len(inds) == 6
 
 
 class Counter:
@@ -137,7 +137,7 @@ def test_meet_budget_count_nonviable():
 
     inds = my_accumulate.individuals()
 
-    assert len(inds) == 5
+    assert len(inds) == 7
 
 def test_meet_budget_do_not_count_nonviable():
     """ Birth budget without counting non-viable individuals """
@@ -166,4 +166,4 @@ def test_meet_budget_do_not_count_nonviable():
 
     inds = my_accumulate.individuals()
 
-    assert len(inds) == 4
+    assert len(inds) == 6


### PR DESCRIPTION
When individuals are born, they are already added to the birth counter. When checking for viability, non-viable individuals are counted down (if told to do such), but viable individuals were counted again.