### PR TITLE
Change singular ranks to have 0 distance

### DIFF
--- a/tests/multiobjective/test_ops.py
+++ b/tests/multiobjective/test_ops.py
@@ -59,8 +59,8 @@ def generate_test_pop():
     # 3-2 argsort: 0  [16, 16]
     
     distances = [
-        np.inf, # Edge
-        np.inf, # Edge
+        0, # Edge
+        0, # Edge
         np.inf, # Edge
         (4 - 0) / 4 + (4 - 0) / 4,
         np.inf, # Edge


### PR DESCRIPTION
Fixes the failing test in #267, should close that issue. As discussed, I believe the behavior to be accurate, this was just changing the test to match.