### PR TITLE
Leftover Individual parameters from prior iterations of uuid

### DIFF
--- a/leap_ec/individual.py
+++ b/leap_ec/individual.py
@@ -24,7 +24,7 @@ class Individual:
         converted into phenomes for fitness evaluation.
     """
 
-    def __init__(self, genome, decoder=IdentityDecoder(), problem=None, parent_id=None, child_number=None):
+    def __init__(self, genome, decoder=IdentityDecoder(), problem=None):
         """
         Initialize an `Individual` with a given genome.
 


### PR DESCRIPTION
Accidentally left on some parameters to `Individual` from a prior iteration on adding uuid to all individuals.