### PR TITLE
Replace curry with a new decorator that applies functools.wraps and curry simultaneously

### DIFF
--- a/examples/advanced/multitask_island_model.py
+++ b/examples/advanced/multitask_island_model.py
@@ -8,7 +8,6 @@ import sys
 
 from matplotlib import pyplot as plt
 import networkx as nx
-from toolz import curry
 
 from leap_ec import Individual, Representation, context, test_env_var
 from leap_ec import ops, probe

--- a/leap_ec/binary_rep/ops.py
+++ b/leap_ec/binary_rep/ops.py
@@ -4,17 +4,17 @@
 """
 from random import random
 from typing import Iterator
-from toolz import curry
 
 import numpy as np
 
+from leap_ec.util import wrap_curry
 from leap_ec.ops import compute_expected_probability, iteriter_op, random_bernoulli_vector
 
 
 ##############################
 # Function mutate_bitflip
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def mutate_bitflip(next_individual: Iterator,
                    expected_num_mutations: float = None,
@@ -59,7 +59,7 @@ def mutate_bitflip(next_individual: Iterator,
 ##############################
 # Function perform_mutate_bitflip
 ##############################
-@curry
+@wrap_curry
 def genome_mutate_bitflip(genome: np.ndarray,
                           expected_num_mutations: float = None,
                           probability: float = None) -> np.ndarray:

--- a/leap_ec/distrib/evaluate.py
+++ b/leap_ec/distrib/evaluate.py
@@ -5,14 +5,14 @@
 import time
 import platform
 import os
-from toolz import curry
 
 import distributed
 
+from leap_ec.util import wrap_curry
 from leap_ec.global_vars import context
 
 
-@curry
+@wrap_curry
 def evaluate(individual, context=context):
     """ concurrently evaluate the given individual
 

--- a/leap_ec/distrib/synchronous.py
+++ b/leap_ec/distrib/synchronous.py
@@ -3,10 +3,10 @@
   This provides a synchronous fitness evaluation pipeline operator.
 """
 import logging
-from toolz import curry
 
 from leap_ec import leap_logger_name
 from leap_ec.global_vars import context
+from leap_ec.util import wrap_curry
 
 from .evaluate import evaluate
 from leap_ec import ops
@@ -24,7 +24,7 @@ logger = logging.getLogger(leap_logger_name)
 # logger.addHandler(console_handler)
 
 
-@curry
+@wrap_curry
 @ops.listlist_op
 def eval_population(population, client, context=context):
     """ Concurrently evaluate all the individuals in the given population
@@ -48,7 +48,7 @@ def eval_population(population, client, context=context):
     return evaluated_individuals
 
 
-@curry
+@wrap_curry
 @ops.iterlist_op
 def eval_pool(next_individual, client, size, context=context):
     """ concurrently evaluate `size` individuals

--- a/leap_ec/int_rep/ops.py
+++ b/leap_ec/int_rep/ops.py
@@ -4,8 +4,8 @@ import random
 from typing import Iterator
 
 import numpy as np
-from toolz import curry
 
+from leap_ec.util import wrap_curry
 from leap_ec.ops import compute_expected_probability, iteriter_op, random_bernoulli_vector
 from leap_ec.real_rep.ops import apply_hard_bounds
 
@@ -13,7 +13,7 @@ from leap_ec.real_rep.ops import apply_hard_bounds
 ##############################
 # Function mutate_randint
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def mutate_randint(next_individual: Iterator, bounds,
                    expected_num_mutations = None,
@@ -61,7 +61,7 @@ def mutate_randint(next_individual: Iterator, bounds,
 ##############################
 # Function individual_mutate_randint
 ##############################
-@curry
+@wrap_curry
 def individual_mutate_randint(genome,
                               bounds: list,
                               expected_num_mutations = None,
@@ -112,7 +112,7 @@ def individual_mutate_randint(genome,
 ##############################
 # Function mutate_binomial
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def mutate_binomial(next_individual: Iterator, std: float, bounds: list,
                     expected_num_mutations: float = None,
@@ -229,7 +229,7 @@ def mutate_binomial(next_individual: Iterator, std: float, bounds: list,
 ##############################
 # Function genome_mutate_binomial
 ##############################
-@curry
+@wrap_curry
 def genome_mutate_binomial(std,
                         bounds: list,
                         expected_num_mutations: float = None,

--- a/leap_ec/multiobjective/ops.py
+++ b/leap_ec/multiobjective/ops.py
@@ -10,18 +10,18 @@ import random
 from itertools import chain
 
 import toolz
-from toolz import curry
 from math import inf
 
 import numpy as np
 
 from leap_ec.ops import compute_expected_probability, listlist_op, iteriter_op
+from leap_ec.util import wrap_curry
 from .problems import MultiObjectiveProblem
 
 ##############################
 # sort_by_dominance operator
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def sort_by_dominance(population: list) -> list:
     """ Sort population by rank and distance
@@ -38,7 +38,7 @@ def sort_by_dominance(population: list) -> list:
 ##############################
 # fast_nondominated_sort operator
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def fast_nondominated_sort(population: list, parents: list = None) -> list:
     """ This implements the NSGA-II fast-non-dominated-sort()
@@ -109,7 +109,7 @@ def fast_nondominated_sort(population: list, parents: list = None) -> list:
 ##############################
 # rank_ordinal_sort operator
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def rank_ordinal_sort(population: list, parents: list = None) -> list:
     """ This implements Rank Ordinal Sort from Rank-based Non-dominated Sorting
@@ -241,7 +241,7 @@ def per_rank_crowding_calc(ranked_population: list, is_maximizing) -> list:
 
     return sorted_pop
 
-@curry
+@wrap_curry
 @listlist_op
 def crowding_distance_calc(population: list) -> list:
     """ This implements the NSGA-II crowding-distance-assignment()

--- a/leap_ec/ops.py
+++ b/leap_ec/ops.py
@@ -22,7 +22,7 @@ from typing import Iterator, List, Union, Tuple
 
 import numpy as np
 import toolz
-from toolz import curry
+from leap_ec.util import wrap_curry
 
 from leap_ec import leap_logger_name
 from leap_ec.global_vars import context
@@ -233,7 +233,7 @@ def iterlist_op(f):
 ##############################
 # evaluate operator
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def evaluate(next_individual: Iterator) -> Iterator:
     """ Evaluate and returns the next individual in the pipeline
@@ -267,7 +267,7 @@ def evaluate(next_individual: Iterator) -> Iterator:
 ##############################
 # evaluate operator
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def grouped_evaluate(population: list, max_individuals_per_chunk: int = None) -> list:
     """Evaluate the population by sending groups of multiple individuals to
@@ -302,7 +302,7 @@ def grouped_evaluate(population: list, max_individuals_per_chunk: int = None) ->
 ##############################
 # const_evaluate operator
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def const_evaluate(population: List, value) -> List:
     """An evaluator that assigns a constant fitness to every individual.
@@ -323,7 +323,7 @@ def const_evaluate(population: List, value) -> List:
 ##############################
 # clone operator
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def clone(next_individual: Iterator) -> Iterator:
     """ clones and returns the next individual in the pipeline
@@ -607,7 +607,7 @@ class NAryCrossover(Crossover):
 ##############################
 # Function proportional_selection
 ##############################
-@curry
+@wrap_curry
 @listiter_op
 def proportional_selection(population: List, offset=0, exponent: int = 1,
                            key=lambda x: x.fitness) -> Iterator:
@@ -668,7 +668,7 @@ def proportional_selection(population: List, offset=0, exponent: int = 1,
 ##############################
 # Function sus_selection
 ##############################
-@curry
+@wrap_curry
 @listiter_op
 def sus_selection(population: List, n=None, shuffle: bool = True,
                   offset=0, exponent: int = 1,
@@ -767,7 +767,7 @@ def sus_selection(population: List, n=None, shuffle: bool = True,
 ##############################
 # Function truncation_selection
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def truncation_selection(offspring: List, size: int,
                          parents: List = None,
@@ -818,7 +818,7 @@ def truncation_selection(offspring: List, size: int,
 ##############################
 # Function elitist_survival
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def elitist_survival(offspring: List, parents: List, k: int = 1, key = None) -> List:
     """ This allows k best parents to compete with the offspring.
@@ -895,7 +895,7 @@ def elitist_survival(offspring: List, parents: List, k: int = 1, key = None) -> 
 ##############################
 # Function tournament_selection
 ##############################
-@curry
+@wrap_curry
 @listiter_op
 def tournament_selection(population: list, k: int = 2, key = None, select_worst: bool=False, indices = None) -> Iterator:
     """Returns an operator that selects the best individual from k individuals randomly selected from
@@ -948,7 +948,7 @@ def tournament_selection(population: list, k: int = 2, key = None, select_worst:
 ##############################
 # Function insertion_selection
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def insertion_selection(offspring: List, parents: List, key = None) -> List:
     """ do exclusive selection between offspring and parents
@@ -988,7 +988,7 @@ def insertion_selection(offspring: List, parents: List, key = None) -> List:
 ##############################
 # Function naive_cyclic_selection
 ##############################
-@curry
+@wrap_curry
 @listiter_op
 def naive_cyclic_selection(population: List, indices: List = None) -> Iterator:
     """ Deterministically returns individuals, and repeats the same test_sequence
@@ -1021,7 +1021,7 @@ def naive_cyclic_selection(population: List, indices: List = None) -> Iterator:
 ##############################
 # Function cyclic_selection
 ##############################
-@curry
+@wrap_curry
 @listiter_op
 def cyclic_selection(population: List) -> Iterator:
     """ Deterministically returns individuals in order, then shuffles the
@@ -1057,7 +1057,7 @@ def cyclic_selection(population: List) -> Iterator:
 ##############################
 # Function random_selection
 ##############################
-@curry
+@wrap_curry
 @listiter_op
 def random_selection(population: List, indices = None) -> Iterator:
     """ return a uniformly randomly selected individual from the population
@@ -1078,7 +1078,7 @@ def random_selection(population: List, indices = None) -> Iterator:
 ##############################
 # Function pool
 ##############################
-@curry
+@wrap_curry
 @iterlist_op
 def pool(next_individual: Iterator, size: int) -> List:
     """ 'Sink' for creating `size` individuals from preceding pipeline source.

--- a/leap_ec/parsimony.py
+++ b/leap_ec/parsimony.py
@@ -7,7 +7,8 @@
     Provided are Koza-style parsimony pressure and lexicographic parsimony
     key functions.
 """
-from toolz import curry
+from leap_ec.util import wrap_curry
+
 
 def lexical_parsimony(ind):
     """ If two fitnesses are the same, break the tie with the smallest genome
@@ -52,7 +53,7 @@ def lexical_parsimony(ind):
         return (-ind.fitness, -len(ind.genome))
 
 
-@curry
+@wrap_curry
 def koza_parsimony(ind, *, penalty):
     """ Penalize fitness by genome length times a constant
 

--- a/leap_ec/probe.py
+++ b/leap_ec/probe.py
@@ -11,8 +11,8 @@ from typing import Dict, Iterator
 from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
-from toolz import curry
 
+from leap_ec.util import wrap_curry
 from leap_ec import Individual
 from leap_ec.global_vars import context
 from leap_ec import ops as op
@@ -23,7 +23,7 @@ from leap_ec.util import get_step
 ##############################
 # print_probe
 ##############################
-@curry
+@wrap_curry
 @listlist_op
 def print_probe(population, probe, stream=sys.stdout, prefix=''):
     """ pipeline operator for printing the given population
@@ -50,7 +50,7 @@ def print_probe(population, probe, stream=sys.stdout, prefix=''):
 ##############################
 # print_individual
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def print_individual(next_individual: Iterator, prefix='',
                      stream=sys.stdout) -> Iterator:

--- a/leap_ec/real_rep/ops.py
+++ b/leap_ec/real_rep/ops.py
@@ -8,15 +8,14 @@ from typing import Iterator, List, Tuple, Union
 
 import numpy as np
 
-from toolz import curry
-
+from leap_ec.util import wrap_curry
 from leap_ec.ops import compute_expected_probability, iteriter_op, random_bernoulli_vector
 
 
 ##############################
 # Function mutate_gaussian
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def mutate_gaussian(next_individual: Iterator,
                     std,
@@ -77,7 +76,7 @@ def mutate_gaussian(next_individual: Iterator,
 ##############################
 # Function genome_mutate_gaussian
 ##############################
-@curry
+@wrap_curry
 def genome_mutate_gaussian(genome,
                            std: float,
                            expected_num_mutations,

--- a/leap_ec/segmented_rep/ops.py
+++ b/leap_ec/segmented_rep/ops.py
@@ -4,17 +4,17 @@
 """
 from typing import Iterator, Callable
 import random
-from toolz import curry
 
 import numpy as np
 
+from leap_ec.util import wrap_curry
 from leap_ec.ops import compute_expected_probability, iteriter_op
 
 
 ##############################
 # Function apply_mutation
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def apply_mutation(next_individual: Iterator,
                    mutator: Callable[[list, float], list],
@@ -65,7 +65,7 @@ def apply_mutation(next_individual: Iterator,
 ##############################
 # Function segmented_mutation()
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def segmented_mutate(next_individual: Iterator, mutator_functions: list):
     """
@@ -91,7 +91,7 @@ def segmented_mutate(next_individual: Iterator, mutator_functions: list):
 ##############################
 # add_segment
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def add_segment(next_individual: Iterator,
                 seq_initializer: Callable,
@@ -142,7 +142,7 @@ def add_segment(next_individual: Iterator,
 ##############################
 # remove_segment
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def remove_segment(next_individual: Iterator,
                    probability: float) -> Iterator:
@@ -180,7 +180,7 @@ def remove_segment(next_individual: Iterator,
 ##############################
 # copy_segment
 ##############################
-@curry
+@wrap_curry
 @iteriter_op
 def copy_segment(next_individual: Iterator,
                  probability: float,

--- a/leap_ec/util.py
+++ b/leap_ec/util.py
@@ -10,8 +10,20 @@
 import collections
 import itertools
 import inspect
+from functools import wraps
+from toolz import curry
 
 from leap_ec.global_vars import context
+
+
+###############################
+# Function wrap_curry
+###############################
+def wrap_curry(f):
+    """
+    Wraps and curries in conjunction, so the function signature remains.
+    """
+    return wraps(f)(curry(f))
 
 
 ###############################


### PR DESCRIPTION
Makes the change I mentioned in #286 

Replaces usages of `@curry` with `@wrap_curry`, a decorator that calls both `curry` and `functools.wraps`. This lets the function signature and docstring follow through for python language servers, enabling auto complete and descriptions when hovering.