### PR TITLE
Extend crossover childrens' parents with the opposing children's

### DIFF
--- a/leap_ec/distrib/individual.py
+++ b/leap_ec/distrib/individual.py
@@ -11,6 +11,7 @@
 import itertools
 
 from leap_ec.individual import RobustIndividual
+import pickle
 
 
 class DistributedIndividual(RobustIndividual):
@@ -32,6 +33,11 @@ class DistributedIndividual(RobustIndividual):
         self.stop_eval_time = None
         self.is_viable = False
         self.exception = None
+    
+    def clone(self):
+        cloned = super().clone()
+        cloned.birth_id = next(DistributedIndividual.birth_id)
+        return cloned
 
     def __str__(self):
         return f'{self.uuid} birth: {self.birth_id} fitness: {self.fitness!s} ' \

--- a/leap_ec/individual.py
+++ b/leap_ec/individual.py
@@ -70,8 +70,8 @@ class Individual:
         self._phenome = None
         
         self.uuid = uuid.uuid4()
-        self.parents = []
-        self.children = []
+        self.parents = set()
+        self.children = set()
 
     @property
     def phenome(self):
@@ -139,8 +139,8 @@ class Individual:
         cloned.fitness = None
 
         cloned.uuid = uuid.uuid4()
-        cloned.parents = [self.uuid]
-        self.children.append(cloned.uuid)
+        cloned.parents = {self.uuid}
+        self.children.add(cloned.uuid)
         
         return cloned
 

--- a/leap_ec/ops.py
+++ b/leap_ec/ops.py
@@ -389,6 +389,10 @@ class Crossover(Operator):
                     first_child, self.second_child = parent_a, parent_b
                 else:
                     first_child, self.second_child = self.recombine(parent_a, parent_b)
+                    
+                    first_child.parents.extend(self.second_child.parents)
+                    self.second_child.parents.extend(first_child.parents)
+
                     first_child.fitness = self.second_child.fitness = None
                 
                 # Generators only execute code if necessary, so children will only be generated

--- a/leap_ec/ops.py
+++ b/leap_ec/ops.py
@@ -390,8 +390,8 @@ class Crossover(Operator):
                 else:
                     first_child, self.second_child = self.recombine(parent_a, parent_b)
                     
-                    first_child.parents.extend(self.second_child.parents)
-                    self.second_child.parents.extend(first_child.parents)
+                    first_child.parents |= self.second_child.parents
+                    self.second_child.parents |= first_child.parents
 
                     first_child.fitness = self.second_child.fitness = None
                 


### PR DESCRIPTION
This was a feature I intentionally left out of the lineage tracking issue due to confusion over a conversation with Mark.

At the time of crossover, the two children individuals have their parents list extended with the parents list of the other child. This should work with any sequence of prior modifications to the parents list.

Note that this feature is missing tests at the time of PR.